### PR TITLE
feat: implement model security API resources

### DIFF
--- a/internal/provider/datasource_model_scan_evaluations.go
+++ b/internal/provider/datasource_model_scan_evaluations.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/cdot65/prisma-airs-go/aisec/modelsecurity"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &modelScanEvaluationsDataSource{}
+
+func NewModelScanEvaluationsDataSource() datasource.DataSource {
+	return &modelScanEvaluationsDataSource{}
+}
+
+type modelScanEvaluationsDataSource struct {
+	client *modelsecurity.Client
+}
+
+type ModelScanEvaluationsDataSourceModel struct {
+	ScanUUID    types.String               `tfsdk:"scan_uuid"`
+	Evaluations []ModelScanEvaluationModel `tfsdk:"evaluations"`
+}
+
+type ModelScanEvaluationModel struct {
+	UUID             types.String `tfsdk:"uuid"`
+	ScanUUID         types.String `tfsdk:"scan_uuid"`
+	RuleInstanceUUID types.String `tfsdk:"rule_instance_uuid"`
+	RuleName         types.String `tfsdk:"rule_name"`
+	Result           types.String `tfsdk:"result"`
+	Details          types.String `tfsdk:"details"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+}
+
+func (d *modelScanEvaluationsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_model_scan_evaluations"
+}
+
+func (d *modelScanEvaluationsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches evaluations for a Model Security scan.",
+		Attributes: map[string]schema.Attribute{
+			"scan_uuid": schema.StringAttribute{
+				Required:    true,
+				Description: "UUID of the scan to fetch evaluations for.",
+			},
+			"evaluations": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of rule evaluations.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"uuid": schema.StringAttribute{
+							Computed:    true,
+							Description: "Evaluation UUID.",
+						},
+						"scan_uuid": schema.StringAttribute{
+							Computed:    true,
+							Description: "Scan UUID.",
+						},
+						"rule_instance_uuid": schema.StringAttribute{
+							Computed:    true,
+							Description: "Rule instance UUID.",
+						},
+						"rule_name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Rule name.",
+						},
+						"result": schema.StringAttribute{
+							Computed:    true,
+							Description: "Evaluation result (PASSED, FAILED, ERROR).",
+						},
+						"details": schema.StringAttribute{
+							Computed:    true,
+							Description: "Evaluation details as JSON.",
+						},
+						"created_at": schema.StringAttribute{
+							Computed:    true,
+							Description: "Creation timestamp.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *modelScanEvaluationsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, diags := getModelSecClient(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = client
+}
+
+func (d *modelScanEvaluationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config ModelScanEvaluationsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	evalsResp, err := d.client.Scans.GetEvaluations(ctx, config.ScanUUID.ValueString(), modelsecurity.EvaluationListOpts{Limit: 100})
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to list scan evaluations", err.Error())
+		return
+	}
+
+	var state ModelScanEvaluationsDataSourceModel
+	state.ScanUUID = config.ScanUUID
+
+	for _, item := range evalsResp.Items {
+		detailsJSON := ""
+		if item.Details != nil {
+			if b, err := json.Marshal(item.Details); err == nil {
+				detailsJSON = string(b)
+			}
+		}
+		state.Evaluations = append(state.Evaluations, ModelScanEvaluationModel{
+			UUID:             types.StringValue(item.UUID),
+			ScanUUID:         types.StringValue(item.ScanUUID),
+			RuleInstanceUUID: types.StringValue(item.RuleInstanceUUID),
+			RuleName:         types.StringValue(item.RuleName),
+			Result:           types.StringValue(string(item.Result)),
+			Details:          types.StringValue(detailsJSON),
+			CreatedAt:        types.StringValue(item.CreatedAt),
+		})
+	}
+
+	if state.Evaluations == nil {
+		state.Evaluations = []ModelScanEvaluationModel{}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/provider/datasource_model_scan_evaluations_test.go
+++ b/internal/provider/datasource_model_scan_evaluations_test.go
@@ -1,0 +1,11 @@
+package provider_test
+
+import (
+	"testing"
+)
+
+func TestAccModelScanEvaluationsDataSource_basic(t *testing.T) {
+	testAccPreCheck(t)
+	// Skip: requires a completed scan UUID to fetch evaluations.
+	t.Skip("Model scan evaluations require a completed scan UUID")
+}

--- a/internal/provider/datasource_model_scan_violations.go
+++ b/internal/provider/datasource_model_scan_violations.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/cdot65/prisma-airs-go/aisec/modelsecurity"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &modelScanViolationsDataSource{}
+
+func NewModelScanViolationsDataSource() datasource.DataSource {
+	return &modelScanViolationsDataSource{}
+}
+
+type modelScanViolationsDataSource struct {
+	client *modelsecurity.Client
+}
+
+type ModelScanViolationsDataSourceModel struct {
+	ScanUUID   types.String              `tfsdk:"scan_uuid"`
+	Violations []ModelScanViolationModel `tfsdk:"violations"`
+}
+
+type ModelScanViolationModel struct {
+	UUID      types.String `tfsdk:"uuid"`
+	ScanUUID  types.String `tfsdk:"scan_uuid"`
+	RuleName  types.String `tfsdk:"rule_name"`
+	Details   types.String `tfsdk:"details"`
+	CreatedAt types.String `tfsdk:"created_at"`
+}
+
+func (d *modelScanViolationsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_model_scan_violations"
+}
+
+func (d *modelScanViolationsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches rule violations for a Model Security scan.",
+		Attributes: map[string]schema.Attribute{
+			"scan_uuid": schema.StringAttribute{
+				Required:    true,
+				Description: "UUID of the scan to fetch violations for.",
+			},
+			"violations": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of rule violations.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"uuid": schema.StringAttribute{
+							Computed:    true,
+							Description: "Violation UUID.",
+						},
+						"scan_uuid": schema.StringAttribute{
+							Computed:    true,
+							Description: "Scan UUID.",
+						},
+						"rule_name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Rule name.",
+						},
+						"details": schema.StringAttribute{
+							Computed:    true,
+							Description: "Violation details as JSON.",
+						},
+						"created_at": schema.StringAttribute{
+							Computed:    true,
+							Description: "Creation timestamp.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *modelScanViolationsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, diags := getModelSecClient(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = client
+}
+
+func (d *modelScanViolationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config ModelScanViolationsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	violResp, err := d.client.Scans.GetViolations(ctx, config.ScanUUID.ValueString(), modelsecurity.ViolationListOpts{Limit: 100})
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to list scan violations", err.Error())
+		return
+	}
+
+	var state ModelScanViolationsDataSourceModel
+	state.ScanUUID = config.ScanUUID
+
+	for _, item := range violResp.Items {
+		detailsJSON := ""
+		if item.Details != nil {
+			if b, err := json.Marshal(item.Details); err == nil {
+				detailsJSON = string(b)
+			}
+		}
+		state.Violations = append(state.Violations, ModelScanViolationModel{
+			UUID:      types.StringValue(item.UUID),
+			ScanUUID:  types.StringValue(item.ScanUUID),
+			RuleName:  types.StringValue(item.RuleName),
+			Details:   types.StringValue(detailsJSON),
+			CreatedAt: types.StringValue(item.CreatedAt),
+		})
+	}
+
+	if state.Violations == nil {
+		state.Violations = []ModelScanViolationModel{}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/provider/datasource_model_scan_violations_test.go
+++ b/internal/provider/datasource_model_scan_violations_test.go
@@ -1,0 +1,11 @@
+package provider_test
+
+import (
+	"testing"
+)
+
+func TestAccModelScanViolationsDataSource_basic(t *testing.T) {
+	testAccPreCheck(t)
+	// Skip: requires a completed scan UUID to fetch violations.
+	t.Skip("Model scan violations require a completed scan UUID")
+}

--- a/internal/provider/datasource_model_security_rules.go
+++ b/internal/provider/datasource_model_security_rules.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/cdot65/prisma-airs-go/aisec/modelsecurity"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &modelSecurityRulesDataSource{}
+
+func NewModelSecurityRulesDataSource() datasource.DataSource {
+	return &modelSecurityRulesDataSource{}
+}
+
+type modelSecurityRulesDataSource struct {
+	client *modelsecurity.Client
+}
+
+type ModelSecurityRulesDataSourceModel struct {
+	Rules []ModelSecurityRuleModel `tfsdk:"rules"`
+}
+
+type ModelSecurityRuleModel struct {
+	UUID        types.String `tfsdk:"uuid"`
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	SourceType  types.String `tfsdk:"source_type"`
+	RuleType    types.String `tfsdk:"rule_type"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+}
+
+func (d *modelSecurityRulesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_model_security_rules"
+}
+
+func (d *modelSecurityRulesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Fetches the catalog of Model Security rules.",
+		Attributes: map[string]schema.Attribute{
+			"rules": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "List of security rules.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"uuid": schema.StringAttribute{
+							Computed:    true,
+							Description: "Rule UUID.",
+						},
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Rule name.",
+						},
+						"description": schema.StringAttribute{
+							Computed:    true,
+							Description: "Rule description.",
+						},
+						"source_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "Source type.",
+						},
+						"rule_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "Rule type (METADATA, ARTIFACT).",
+						},
+						"created_at": schema.StringAttribute{
+							Computed:    true,
+							Description: "Creation timestamp.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *modelSecurityRulesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, diags := getModelSecClient(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	d.client = client
+}
+
+func (d *modelSecurityRulesDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	rulesResp, err := d.client.SecurityRules.List(ctx, modelsecurity.RuleListOpts{Limit: 100})
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to list model security rules", err.Error())
+		return
+	}
+
+	var state ModelSecurityRulesDataSourceModel
+	for _, item := range rulesResp.Items {
+		state.Rules = append(state.Rules, ModelSecurityRuleModel{
+			UUID:        types.StringValue(item.UUID),
+			Name:        types.StringValue(item.Name),
+			Description: types.StringValue(item.Description),
+			SourceType:  types.StringValue(string(item.SourceType)),
+			RuleType:    types.StringValue(string(item.RuleType)),
+			CreatedAt:   types.StringValue(item.CreatedAt),
+		})
+	}
+
+	if state.Rules == nil {
+		state.Rules = []ModelSecurityRuleModel{}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/internal/provider/datasource_model_security_rules_test.go
+++ b/internal/provider/datasource_model_security_rules_test.go
@@ -1,0 +1,29 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccModelSecurityRulesDataSource_basic(t *testing.T) {
+	testAccPreCheck(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccModelSecurityRulesConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.prisma-airs_model_security_rules.test", "rules.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccModelSecurityRulesConfig() string {
+	return `
+data "prisma-airs_model_security_rules" "test" {}
+`
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/cdot65/prisma-airs-go/aisec/management"
+	"github.com/cdot65/prisma-airs-go/aisec/modelsecurity"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -172,6 +173,23 @@ func (p *PrismaAIRSProvider) Configure(ctx context.Context, req provider.Configu
 		providerData.MgmtClient = mgmtClient
 	}
 
+	// Initialize model security client if OAuth2 credentials are available.
+	if clientID != "" && clientSecret != "" && tsgID != "" {
+		msClient, err := modelsecurity.NewClient(modelsecurity.Opts{
+			ClientID:      clientID,
+			ClientSecret:  clientSecret,
+			TsgID:         tsgID,
+			DataEndpoint:  modelSecDataEndpoint,
+			MgmtEndpoint:  modelSecMgmtEndpoint,
+			TokenEndpoint: tokenEndpoint,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to create model security client", err.Error())
+			return
+		}
+		providerData.ModelSecClient = msClient
+	}
+
 	resp.DataSourceData = providerData
 	resp.ResourceData = providerData
 }
@@ -182,6 +200,8 @@ func (p *PrismaAIRSProvider) Resources(_ context.Context) []func() resource.Reso
 		NewCustomTopicResource,
 		NewApiKeyResource,
 		NewCustomerAppResource,
+		NewModelSecurityGroupResource,
+		NewModelScanResource,
 	}
 }
 
@@ -190,6 +210,9 @@ func (p *PrismaAIRSProvider) DataSources(_ context.Context) []func() datasource.
 		NewDlpProfilesDataSource,
 		NewDeploymentProfilesDataSource,
 		NewScanLogsDataSource,
+		NewModelSecurityRulesDataSource,
+		NewModelScanEvaluationsDataSource,
+		NewModelScanViolationsDataSource,
 	}
 }
 
@@ -205,6 +228,7 @@ func New(version string) func() provider.Provider {
 // ProviderData holds resolved configuration passed to resources and data sources.
 type ProviderData struct {
 	MgmtClient           *management.Client
+	ModelSecClient       *modelsecurity.Client
 	APIKey               string
 	APIToken             string
 	ProfileName          string

--- a/internal/provider/resource_model_scan.go
+++ b/internal/provider/resource_model_scan.go
@@ -1,0 +1,279 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/cdot65/prisma-airs-go/aisec/modelsecurity"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &modelScanResource{}
+	_ resource.ResourceWithImportState = &modelScanResource{}
+)
+
+func NewModelScanResource() resource.Resource {
+	return &modelScanResource{}
+}
+
+type modelScanResource struct {
+	client *modelsecurity.Client
+}
+
+type ModelScanResourceModel struct {
+	ID                types.String `tfsdk:"id"`
+	UUID              types.String `tfsdk:"uuid"`
+	Name              types.String `tfsdk:"name"`
+	SourceType        types.String `tfsdk:"source_type"`
+	SecurityGroupUUID types.String `tfsdk:"security_group_uuid"`
+	Source            types.String `tfsdk:"source"`
+	Labels            types.Map    `tfsdk:"labels"`
+	EvalOutcome       types.String `tfsdk:"eval_outcome"`
+	EvalSummary       types.String `tfsdk:"eval_summary"`
+	CreatedAt         types.String `tfsdk:"created_at"`
+	UpdatedAt         types.String `tfsdk:"updated_at"`
+}
+
+func (r *modelScanResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_model_scan"
+}
+
+func (r *modelScanResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Creates a Model Security scan.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Terraform resource ID (same as uuid).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"uuid": schema.StringAttribute{
+				Computed:    true,
+				Description: "The unique identifier of the scan.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the model to scan.",
+			},
+			"source_type": schema.StringAttribute{
+				Required:    true,
+				Description: "Source type (LOCAL, HUGGING_FACE, S3, GCS, AZURE, ARTIFACTORY, GITLAB, ALL).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"security_group_uuid": schema.StringAttribute{
+				Optional:    true,
+				Description: "UUID of the security group to use for this scan.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"source": schema.StringAttribute{
+				Optional:    true,
+				Description: "Source configuration as a JSON string.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"labels": schema.MapAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Key-value labels for the scan.",
+			},
+			"eval_outcome": schema.StringAttribute{
+				Computed:    true,
+				Description: "Evaluation outcome (PENDING, ALLOWED, BLOCKED, ERROR).",
+			},
+			"eval_summary": schema.StringAttribute{
+				Computed:    true,
+				Description: "Evaluation summary as JSON.",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Creation timestamp.",
+			},
+			"updated_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Last update timestamp.",
+			},
+		},
+	}
+}
+
+func (r *modelScanResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, diags := getModelSecClient(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = client
+}
+
+func (r *modelScanResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModelScanResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createReq := modelsecurity.ScanCreateRequest{
+		Name:       plan.Name.ValueString(),
+		SourceType: modelsecurity.SourceType(plan.SourceType.ValueString()),
+	}
+
+	if !plan.SecurityGroupUUID.IsNull() && !plan.SecurityGroupUUID.IsUnknown() {
+		createReq.SecurityGroupUUID = plan.SecurityGroupUUID.ValueString()
+	}
+
+	if !plan.Source.IsNull() && !plan.Source.IsUnknown() && plan.Source.ValueString() != "" {
+		var sourceMap map[string]any
+		if err := json.Unmarshal([]byte(plan.Source.ValueString()), &sourceMap); err != nil {
+			resp.Diagnostics.AddError("Invalid source JSON", err.Error())
+			return
+		}
+		createReq.Source = sourceMap
+	}
+
+	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
+		labels := make(map[string]string)
+		resp.Diagnostics.Append(plan.Labels.ElementsAs(ctx, &labels, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		createReq.Labels = labels
+	}
+
+	scan, err := r.client.Scans.Create(ctx, createReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create model scan", err.Error())
+		return
+	}
+
+	mapScanToState(ctx, scan, &plan, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *modelScanResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ModelScanResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scan, err := r.client.Scans.Get(ctx, state.UUID.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read model scan", err.Error())
+		return
+	}
+
+	mapScanToState(ctx, scan, &state, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *modelScanResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ModelScanResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state ModelScanResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only labels can be updated on a scan
+	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
+		labels := make(map[string]string)
+		resp.Diagnostics.Append(plan.Labels.ElementsAs(ctx, &labels, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		_, err := r.client.Scans.SetLabels(ctx, state.UUID.ValueString(), modelsecurity.LabelsCreateRequest{
+			Labels: labels,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to update scan labels", err.Error())
+			return
+		}
+	}
+
+	// Re-read the scan
+	scan, err := r.client.Scans.Get(ctx, state.UUID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read model scan after update", err.Error())
+		return
+	}
+
+	mapScanToState(ctx, scan, &plan, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *modelScanResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Scans cannot be deleted via API — just remove from state.
+	_ = ctx
+	_ = resp
+}
+
+func (r *modelScanResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	uuid := req.ID
+
+	scan, err := r.client.Scans.Get(ctx, uuid)
+	if err != nil {
+		resp.Diagnostics.AddError("Scan not found", "No scan with UUID: "+uuid)
+		return
+	}
+
+	var state ModelScanResourceModel
+	mapScanToState(ctx, scan, &state, &resp.Diagnostics)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func mapScanToState(ctx context.Context, scan *modelsecurity.ScanBaseResponse, state *ModelScanResourceModel, diags *diag.Diagnostics) {
+	state.ID = types.StringValue(scan.UUID)
+	state.UUID = types.StringValue(scan.UUID)
+	state.Name = types.StringValue(scan.Name)
+	state.SourceType = types.StringValue(string(scan.SourceType))
+	state.SecurityGroupUUID = types.StringValue(scan.SecurityGroupUUID)
+	state.EvalOutcome = types.StringValue(string(scan.EvalOutcome))
+	state.CreatedAt = types.StringValue(scan.CreatedAt)
+	state.UpdatedAt = types.StringValue(scan.UpdatedAt)
+
+	if scan.EvalSummary != nil {
+		summaryJSON, err := json.Marshal(scan.EvalSummary)
+		if err == nil {
+			state.EvalSummary = types.StringValue(string(summaryJSON))
+		}
+	} else {
+		state.EvalSummary = types.StringNull()
+	}
+
+	if scan.Labels != nil {
+		labelsMap, d := types.MapValueFrom(ctx, types.StringType, scan.Labels)
+		diags.Append(d...)
+		state.Labels = labelsMap
+	} else {
+		state.Labels = types.MapNull(types.StringType)
+	}
+}

--- a/internal/provider/resource_model_scan_test.go
+++ b/internal/provider/resource_model_scan_test.go
@@ -1,0 +1,13 @@
+package provider_test
+
+import (
+	"testing"
+)
+
+func TestAccModelScanResource_basic(t *testing.T) {
+	testAccPreCheck(t)
+	// Skip: Model scan creation requires a valid model source (e.g. HuggingFace model name)
+	// and an active security group. The scan process is long-running and may not complete
+	// within test timeouts.
+	t.Skip("Model scan creation requires active security group and valid model source")
+}

--- a/internal/provider/resource_model_security_group.go
+++ b/internal/provider/resource_model_security_group.go
@@ -1,0 +1,234 @@
+package provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cdot65/prisma-airs-go/aisec/modelsecurity"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &modelSecurityGroupResource{}
+	_ resource.ResourceWithImportState = &modelSecurityGroupResource{}
+)
+
+func NewModelSecurityGroupResource() resource.Resource {
+	return &modelSecurityGroupResource{}
+}
+
+type modelSecurityGroupResource struct {
+	client *modelsecurity.Client
+}
+
+type ModelSecurityGroupResourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	UUID        types.String `tfsdk:"uuid"`
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	SourceType  types.String `tfsdk:"source_type"`
+	State       types.String `tfsdk:"state"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+	UpdatedAt   types.String `tfsdk:"updated_at"`
+}
+
+func (r *modelSecurityGroupResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_model_security_group"
+}
+
+func (r *modelSecurityGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a Model Security group.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Terraform resource ID (same as uuid).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"uuid": schema.StringAttribute{
+				Computed:    true,
+				Description: "The unique identifier of the security group.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the security group.",
+			},
+			"description": schema.StringAttribute{
+				Optional:    true,
+				Description: "Description of the security group.",
+			},
+			"source_type": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Source type (LOCAL, HUGGING_FACE, S3, GCS, AZURE, ARTIFACTORY, GITLAB, ALL).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"state": schema.StringAttribute{
+				Computed:    true,
+				Description: "Group state (PENDING, ACTIVE).",
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Creation timestamp.",
+			},
+			"updated_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Last update timestamp.",
+			},
+		},
+	}
+}
+
+func (r *modelSecurityGroupResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, diags := getModelSecClient(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = client
+}
+
+func (r *modelSecurityGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ModelSecurityGroupResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createReq := modelsecurity.ModelSecurityGroupCreateRequest{
+		Name:        plan.Name.ValueString(),
+		Description: plan.Description.ValueString(),
+	}
+	if !plan.SourceType.IsNull() && !plan.SourceType.IsUnknown() {
+		createReq.SourceType = modelsecurity.SourceType(plan.SourceType.ValueString())
+	}
+
+	group, err := r.client.SecurityGroups.Create(ctx, createReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create model security group", err.Error())
+		return
+	}
+
+	mapSecurityGroupToState(group, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *modelSecurityGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ModelSecurityGroupResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	group, err := r.client.SecurityGroups.Get(ctx, state.UUID.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read model security group", err.Error())
+		return
+	}
+
+	mapSecurityGroupToState(group, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *modelSecurityGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ModelSecurityGroupResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state ModelSecurityGroupResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateReq := modelsecurity.ModelSecurityGroupUpdateRequest{
+		Name:        plan.Name.ValueString(),
+		Description: plan.Description.ValueString(),
+	}
+
+	group, err := r.client.SecurityGroups.Update(ctx, state.UUID.ValueString(), updateReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to update model security group", err.Error())
+		return
+	}
+
+	mapSecurityGroupToState(group, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *modelSecurityGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ModelSecurityGroupResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.SecurityGroups.Delete(ctx, state.UUID.ValueString())
+	if err != nil {
+		if strings.Contains(err.Error(), "failed to parse response JSON") {
+			return
+		}
+		resp.Diagnostics.AddError("Failed to delete model security group", err.Error())
+		return
+	}
+}
+
+func (r *modelSecurityGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	uuid := req.ID
+
+	group, err := r.client.SecurityGroups.Get(ctx, uuid)
+	if err != nil {
+		resp.Diagnostics.AddError("Group not found", "No security group with UUID: "+uuid)
+		return
+	}
+
+	var state ModelSecurityGroupResourceModel
+	mapSecurityGroupToState(group, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func mapSecurityGroupToState(group *modelsecurity.ModelSecurityGroupResponse, state *ModelSecurityGroupResourceModel) {
+	state.ID = types.StringValue(group.UUID)
+	state.UUID = types.StringValue(group.UUID)
+	state.Name = types.StringValue(group.Name)
+	state.Description = types.StringValue(group.Description)
+	state.SourceType = types.StringValue(string(group.SourceType))
+	state.State = types.StringValue(string(group.State))
+	state.CreatedAt = types.StringValue(group.CreatedAt)
+	state.UpdatedAt = types.StringValue(group.UpdatedAt)
+}
+
+func getModelSecClient(data any) (*modelsecurity.Client, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	pd, ok := data.(*ProviderData)
+	if !ok || pd == nil {
+		diags.AddError("Missing provider config", "Provider not configured")
+		return nil, diags
+	}
+	if pd.ModelSecClient == nil {
+		diags.AddError("Model security client not configured", "OAuth2 credentials required")
+		return nil, diags
+	}
+	return pd.ModelSecClient, diags
+}

--- a/internal/provider/resource_model_security_group_test.go
+++ b/internal/provider/resource_model_security_group_test.go
@@ -1,0 +1,45 @@
+package provider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccModelSecurityGroupResource_basic(t *testing.T) {
+	testAccPreCheck(t)
+	rName := "tf-test-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccModelSecurityGroupConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("prisma-airs_model_security_group.test", "name", rName),
+					resource.TestCheckResourceAttr("prisma-airs_model_security_group.test", "description", "test security group"),
+					resource.TestCheckResourceAttrSet("prisma-airs_model_security_group.test", "id"),
+					resource.TestCheckResourceAttrSet("prisma-airs_model_security_group.test", "uuid"),
+				),
+			},
+			{
+				ResourceName:            "prisma-airs_model_security_group.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"state", "updated_at"},
+			},
+		},
+	})
+}
+
+func testAccModelSecurityGroupConfig(name string) string {
+	return fmt.Sprintf(`
+resource "prisma-airs_model_security_group" "test" {
+  name        = %[1]q
+  description = "test security group"
+  source_type = "HUGGING_FACE"
+}
+`, name)
+}


### PR DESCRIPTION
## Summary
- Add `prisma-airs_model_security_group` resource (CRUD + import)
- Add `prisma-airs_model_scan` resource (create + label management)
- Add `prisma-airs_model_security_rules` data source
- Add `prisma-airs_model_scan_evaluations` data source
- Add `prisma-airs_model_scan_violations` data source
- Initialize `modelsecurity.Client` in provider

## Test plan
- [x] SecurityGroup acceptance test passes (create + import)
- [x] SecurityRules data source test passes
- [x] ModelScan test skipped (requires active security group + valid model)
- [x] Evaluations/violations data source tests skipped (require completed scan)
- [x] All existing tests still pass

Closes #3