### PR TITLE
fix: address CRUD review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,8 @@ internal/provider/
   datasource_scan_logs.go
   datasource_model_security_rules.go
   datasource_model_scan_evaluations.go
+  datasource_model_scan_violations.go
   datasource_content_scan.go
-  datasource_red_team_reports.go
   datasource_red_team_categories.go
   datasource_red_team_quota.go
 ```
@@ -72,7 +72,7 @@ internal/provider/
 
 ## Conventions
 
-- Go 1.22+ minimum
+- Go 1.24+ minimum (go.mod targets 1.25)
 - All resources implement `resource.Resource` + `resource.ResourceWithImportState`
 - All data sources implement `datasource.DataSource`
 - Test files: `*_test.go` alongside source, use `testAccProtoV6ProviderFactories`

--- a/internal/provider/datasource_deployment_profiles.go
+++ b/internal/provider/datasource_deployment_profiles.go
@@ -51,7 +51,7 @@ func (d *deploymentProfilesDataSource) Schema(_ context.Context, _ datasource.Sc
 			},
 			"total_count": schema.Int64Attribute{
 				Computed:    true,
-				Description: "Total number of deployment profiles.",
+				Description: "Number of deployment profiles returned.",
 			},
 			"items": schema.ListNestedAttribute{
 				Computed:    true,

--- a/internal/provider/datasource_dlp_profiles.go
+++ b/internal/provider/datasource_dlp_profiles.go
@@ -51,7 +51,7 @@ func (d *dlpProfilesDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			},
 			"total_count": schema.Int64Attribute{
 				Computed:    true,
-				Description: "Total number of DLP profiles.",
+				Description: "Number of DLP profiles returned.",
 			},
 			"items": schema.ListNestedAttribute{
 				Computed:    true,

--- a/internal/provider/resource_api_key.go
+++ b/internal/provider/resource_api_key.go
@@ -137,10 +137,12 @@ func (r *apiKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	// Preserve the api_key value from state since it's only returned at creation.
+	// Preserve write-only values from state since they're not returned by the API.
 	apiKeyVal := state.ApiKey
+	updatedByVal := state.UpdatedBy
 	mapApiKeyToState(found, &state)
 	state.ApiKey = apiKeyVal
+	state.UpdatedBy = updatedByVal
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/internal/provider/resource_customer_app.go
+++ b/internal/provider/resource_customer_app.go
@@ -119,6 +119,10 @@ func (r *customerAppResource) Read(ctx context.Context, req resource.ReadRequest
 
 	app, err := r.client.CustomerApps.Get(ctx, state.AppID.ValueString())
 	if err != nil {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Failed to read customer app", err.Error())
 		return
 	}

--- a/internal/provider/resource_model_scan.go
+++ b/internal/provider/resource_model_scan.go
@@ -186,7 +186,10 @@ func (r *modelScanResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	// Preserve write-only Source value from prior state (not returned by API).
+	sourceVal := state.Source
 	mapScanToState(ctx, scan, &state, &resp.Diagnostics)
+	state.Source = sourceVal
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/internal/provider/resource_red_team_custom_prompt_set.go
+++ b/internal/provider/resource_red_team_custom_prompt_set.go
@@ -156,7 +156,10 @@ func (r *redTeamCustomPromptSetResource) Read(ctx context.Context, req resource.
 		return
 	}
 
+	// Preserve write-only Properties value from prior state (not returned by API).
+	propsVal := state.Properties
 	mapPromptSetToState(promptSet, &state)
+	state.Properties = propsVal
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 


### PR DESCRIPTION
## Summary
- Fix `customer_app` Read missing 404 handling — externally deleted resources now gracefully removed from state
- Fix `api_key` Read not preserving `updated_by` (write-only field not returned by API)
- Fix `model_scan` Read not preserving `source` (write-only field not returned by API)
- Fix `custom_prompt_set` Read not preserving `properties` (write-only field not returned by API)
- Fix `dlp_profiles`/`deployment_profiles` `total_count` description accuracy

## Test plan
- [x] All 10 acceptance tests pass
- [x] Build, vet, format clean