### PR TITLE
docs: align project files with current provider state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,4 @@
-# ── Scan API (API key or bearer token auth) ──────────────────────────
-PANW_AI_SEC_API_KEY=
-PANW_AI_SEC_API_TOKEN=
-PANW_AI_SEC_PROFILE_NAME=
-# PANW_AI_SEC_API_ENDPOINT=https://service.api.aisecurity.paloaltonetworks.com
-
-# ── Management API (OAuth2 client credentials) ──────────────────────
+# ── OAuth2 credentials (required for all API domains) ────────────────
 PANW_MGMT_CLIENT_ID=
 PANW_MGMT_CLIENT_SECRET=
 PANW_MGMT_TSG_ID=
@@ -12,15 +6,9 @@ PANW_MGMT_TSG_ID=
 # PANW_MGMT_TOKEN_ENDPOINT=https://auth.apps.paloaltonetworks.com/oauth2/access_token
 
 # ── Model Security API (falls back to PANW_MGMT_* vars above) ──────
-# PANW_MODEL_SEC_CLIENT_ID=
-# PANW_MODEL_SEC_CLIENT_SECRET=
-# PANW_MODEL_SEC_TSG_ID=
 # PANW_MODEL_SEC_DATA_ENDPOINT=https://api.sase.paloaltonetworks.com/aims/data
 # PANW_MODEL_SEC_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/aims/mgmt
 
 # ── Red Team API (falls back to PANW_MGMT_* vars above) ────────────
-# PANW_RED_TEAM_CLIENT_ID=
-# PANW_RED_TEAM_CLIENT_SECRET=
-# PANW_RED_TEAM_TSG_ID=
 # PANW_RED_TEAM_DATA_ENDPOINT=https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane
 # PANW_RED_TEAM_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ terraform-provider-prisma-airs
 # Test binary
 *.test
 
+# Debug binary (delve)
+__debug_bin*
+
 # Coverage
 coverage/
 *.out
@@ -37,6 +40,7 @@ REVIEW-*.md
 
 # Terraform
 .terraform/
+.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
 *.tfplan
@@ -48,9 +52,7 @@ override.tf.json
 *_override.tf.json
 .terraformrc
 terraform.rc
+.dev.tfrc
 
 # GoReleaser
 dist/
-
-# Vendor (optional — we use Go modules)
-# vendor/

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![CI](https://github.com/cdot65/prisma-airs-provider/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/prisma-airs-provider/actions/workflows/ci.yml)
 [![Tests](https://github.com/cdot65/prisma-airs-provider/actions/workflows/test.yml/badge.svg)](https://github.com/cdot65/prisma-airs-provider/actions/workflows/test.yml)
-[![Go 1.22+](https://img.shields.io/badge/go-%3E%3D1.22-00ADD8)](https://go.dev/)
+[![Go 1.24+](https://img.shields.io/badge/go-%3E%3D1.24-00ADD8)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Terraform provider for Palo Alto Networks **Prisma AIRS** — managing AI security infrastructure across all four service domains: **AI Runtime Security**, **Management**, **Model Security**, and **AI Red Teaming**.
+Terraform provider for Palo Alto Networks **Prisma AI Runtime Security (AIRS)** — manage AI security infrastructure as code across Management, Model Security, and Red Teaming domains.
 
-Built on the [prisma-airs-go](https://github.com/cdot65/prisma-airs-go) SDK.
+Built on the [prisma-airs-go](https://github.com/cdot65/prisma-airs-go) SDK using the [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework).
 
-## Installation
+## Quick Start
 
 ```hcl
 terraform {
@@ -20,99 +20,38 @@ terraform {
     }
   }
 }
+
+provider "prisma-airs" {}
 ```
-
-## Provider Configuration
-
-```hcl
-provider "prisma-airs" {
-  # AI Runtime Security (API Key auth)
-  api_key      = var.panw_api_key       # or PANW_AI_SEC_API_KEY
-  profile_name = var.panw_profile_name  # or PANW_AI_SEC_PROFILE_NAME
-
-  # Management / Model Security / Red Team (OAuth2 auth)
-  client_id     = var.panw_client_id     # or PANW_MGMT_CLIENT_ID
-  client_secret = var.panw_client_secret # or PANW_MGMT_CLIENT_SECRET
-  tsg_id        = var.panw_tsg_id        # or PANW_MGMT_TSG_ID
-}
-```
-
-## Resources & Data Sources
-
-### Management API
-
-| Type | Name | Description |
-|------|------|-------------|
-| Resource | `prisma-airs_security_profile` | AI security profile CRUD |
-| Resource | `prisma-airs_custom_topic` | Custom detection topic CRUD |
-| Resource | `prisma-airs_api_key` | API key lifecycle management |
-| Resource | `prisma-airs_customer_app` | Customer application management |
-| Data Source | `prisma-airs_dlp_profiles` | DLP data profile listing |
-| Data Source | `prisma-airs_deployment_profiles` | Deployment profile listing |
-| Data Source | `prisma-airs_scan_logs` | Scan activity log queries |
-
-### Model Security API
-
-| Type | Name | Description |
-|------|------|-------------|
-| Resource | `prisma-airs_model_security_group` | Security group CRUD |
-| Resource | `prisma-airs_model_scan` | ML model scan management |
-| Data Source | `prisma-airs_model_security_rules` | Security rule listing |
-| Data Source | `prisma-airs_model_scan_evaluations` | Scan evaluation results |
-| Data Source | `prisma-airs_model_scan_violations` | Scan violation results |
-
-### Red Team API
-
-| Type | Name | Description |
-|------|------|-------------|
-| Resource | `prisma-airs_red_team_target` | Red team target CRUD |
-| Resource | `prisma-airs_red_team_scan` | Red team scan management |
-| Resource | `prisma-airs_red_team_custom_prompt_set` | Custom prompt set management |
-| Data Source | `prisma-airs_red_team_reports` | Scan report data |
-| Data Source | `prisma-airs_red_team_categories` | Attack category listing |
-| Data Source | `prisma-airs_red_team_quota` | Quota information |
-
-### Scan API
-
-| Type | Name | Description |
-|------|------|-------------|
-| Data Source | `prisma-airs_content_scan` | Synchronous content scanning |
-
-## Authentication
-
-| Auth Method | Used By |
-|-------------|---------|
-| **API Key** (HMAC-SHA256) | AI Runtime Security scans only |
-| **OAuth2** (client_credentials) | Management, Model Security, Red Team |
 
 ```bash
-# AI Runtime Security scans
-export PANW_AI_SEC_API_KEY=your-api-key
-
-# OAuth2 (shared by Management, Red Team, Model Security)
-export PANW_MGMT_CLIENT_ID=your-client-id
-export PANW_MGMT_CLIENT_SECRET=your-client-secret
-export PANW_MGMT_TSG_ID=1234567890
+export PANW_MGMT_CLIENT_ID="your-client-id"
+export PANW_MGMT_CLIENT_SECRET="your-client-secret"
+export PANW_MGMT_TSG_ID="1234567890"
+terraform init && terraform apply
 ```
+
+## Coverage
+
+| Domain | Resources | Data Sources |
+|--------|-----------|--------------|
+| Management | `security_profile`, `custom_topic`, `api_key`, `customer_app` | `dlp_profiles`, `deployment_profiles` |
+| Model Security | `model_security_group` | `model_security_rules` |
+| Red Team | `red_team_target`, `red_team_custom_prompt_set` | — |
 
 ## Documentation
 
-Full documentation at **[cdot65.github.io/prisma-airs-provider](https://cdot65.github.io/prisma-airs-provider/)** — includes resource/data source guides, configuration reference, and examples.
+Full docs: **[cdot65.github.io/prisma-airs-provider](https://cdot65.github.io/prisma-airs-provider/)**
 
 ## Development
 
 ```bash
 make build          # build provider binary
-make test           # go test -race ./...
-make testacc        # acceptance tests (requires credentials)
-make test-coverage  # coverage report
-make lint           # golangci-lint
 make check          # fmt + vet + lint + test
-make install        # install locally for development
-make generate       # generate provider docs
+make testacc        # acceptance tests (requires credentials)
 make docs-serve     # serve mkdocs locally
 ```
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,45 +2,32 @@
 
 ## v0.1.0 — Initial Release
 
-### Project Scaffolding
-- Provider skeleton with Terraform Plugin Framework
-- Provider schema with full auth configuration (API Key + OAuth2)
+### Resources (7)
+
+| Resource | Domain |
+|----------|--------|
+| `prisma-airs_security_profile` | Management |
+| `prisma-airs_custom_topic` | Management |
+| `prisma-airs_api_key` | Management |
+| `prisma-airs_customer_app` | Management |
+| `prisma-airs_model_security_group` | Model Security |
+| `prisma-airs_red_team_target` | Red Team |
+| `prisma-airs_red_team_custom_prompt_set` | Red Team |
+
+### Data Sources (3)
+
+| Data Source | Domain |
+|-------------|--------|
+| `prisma-airs_dlp_profiles` | Management |
+| `prisma-airs_deployment_profiles` | Management |
+| `prisma-airs_model_security_rules` | Model Security |
+
+### Infrastructure
+
+- Terraform Plugin Framework (not SDKv2)
+- OAuth2 `client_credentials` authentication for all domains
 - Environment variable fallback for all credentials
-- GoReleaser configuration for binary distribution
-
-### CI/CD
-- GitHub Actions: CI (lint, format, vet), Tests (Go 1.22–1.24 matrix)
-- MkDocs Material documentation site with GitHub Pages deployment
-- Release workflow with GoReleaser and GPG signing
-
-### Documentation
-- Getting started guides (installation, configuration, quick start)
-- Resource documentation for all 9 resources
-- Data source documentation for all 10 data sources
-- Authentication guide
-- Workflow guides (security profiles, model security, red team)
-- Provider configuration reference
-- Environment variable reference
-
-### Planned Resources
-- `prisma-airs_security_profile` — Management API
-- `prisma-airs_custom_topic` — Management API
-- `prisma-airs_api_key` — Management API
-- `prisma-airs_customer_app` — Management API
-- `prisma-airs_model_security_group` — Model Security API
-- `prisma-airs_model_scan` — Model Security API
-- `prisma-airs_red_team_target` — Red Team API
-- `prisma-airs_red_team_scan` — Red Team API
-- `prisma-airs_red_team_custom_prompt_set` — Red Team API
-
-### Planned Data Sources
-- `prisma-airs_content_scan` — Scan API
-- `prisma-airs_dlp_profiles` — Management API
-- `prisma-airs_deployment_profiles` — Management API
-- `prisma-airs_scan_logs` — Management API
-- `prisma-airs_model_security_rules` — Model Security API
-- `prisma-airs_model_scan_evaluations` — Model Security API
-- `prisma-airs_model_scan_violations` — Model Security API
-- `prisma-airs_red_team_reports` — Red Team API
-- `prisma-airs_red_team_categories` — Red Team API
-- `prisma-airs_red_team_quota` — Red Team API
+- GoReleaser with multi-platform builds and GPG signing
+- GitHub Actions CI/CD (lint, test, docs deploy, release)
+- MkDocs Material documentation site
+- E2E test suite with cleanup utility

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -146,10 +146,9 @@
 /* ── Badges ───────────────────────────────────────────────────────── */
 
 .md-typeset img[alt='CI'],
-.md-typeset img[alt='npm'],
-.md-typeset img[alt='License: MIT'],
-.md-typeset img[alt='Node 18+'],
-.md-typeset img[alt='TypeScript'] {
+.md-typeset img[alt='Tests'],
+.md-typeset img[alt='Go 1.24+'],
+.md-typeset img[alt='License: MIT'] {
   display: inline-block;
   vertical-align: middle;
   margin-right: 4px;

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.22 (for building from source)
+- [Go](https://golang.org/doc/install) >= 1.24 (for building from source)
 
 ## Terraform Registry
 

--- a/docs/reference/error-handling.md
+++ b/docs/reference/error-handling.md
@@ -31,13 +31,13 @@ Error: missing required configuration: PANW_MGMT_CLIENT_ID
 
 Set the required environment variables or provider attributes.
 
-### Invalid API Key
+### OAuth2 Authentication Failure
 
 ```
-Error: server returned 403: invalid API key
+Error: Token request failed with status 401
 ```
 
-Verify your API key is valid and not expired.
+Verify your `client_id`, `client_secret`, and `tsg_id` are correct.
 
 ### Rate Limiting
 

--- a/docs/reference/provider-configuration.md
+++ b/docs/reference/provider-configuration.md
@@ -6,13 +6,7 @@ Complete reference for all provider configuration attributes.
 
 ```hcl
 provider "prisma-airs" {
-  # Scan API (API Key auth)
-  api_key      = string  # optional, sensitive
-  api_token    = string  # optional, sensitive
-  profile_name = string  # optional
-  endpoint     = string  # optional
-
-  # OAuth2 (Management, Model Security, Red Team)
+  # OAuth2 (all API domains)
   client_id      = string  # optional
   client_secret  = string  # optional, sensitive
   tsg_id         = string  # optional
@@ -30,15 +24,6 @@ provider "prisma-airs" {
 ```
 
 ## Attribute Reference
-
-### Scan API
-
-| Attribute | Description | Env Var | Default |
-|-----------|-------------|---------|---------|
-| `api_key` | API key for scan operations | `PANW_AI_SEC_API_KEY` | — |
-| `api_token` | Bearer token for scan operations | `PANW_AI_SEC_API_TOKEN` | — |
-| `profile_name` | Default AI security profile name | `PANW_AI_SEC_PROFILE_NAME` | — |
-| `endpoint` | Scan API endpoint | `PANW_AI_SEC_API_ENDPOINT` | `https://service.api.aisecurity.paloaltonetworks.com` |
 
 ### OAuth2
 
@@ -63,3 +48,20 @@ provider "prisma-airs" {
 |-----------|-------------|---------|---------|
 | `red_team_data_endpoint` | Data plane endpoint | `PANW_RED_TEAM_DATA_ENDPOINT` | `https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane` |
 | `red_team_mgmt_endpoint` | Management plane endpoint | `PANW_RED_TEAM_MGMT_ENDPOINT` | `https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane` |
+
+## Minimal Example
+
+```hcl
+# All credentials via environment variables
+provider "prisma-airs" {}
+```
+
+## Full Example
+
+```hcl
+provider "prisma-airs" {
+  client_id     = var.panw_client_id
+  client_secret = var.panw_client_secret
+  tsg_id        = var.panw_tsg_id
+}
+```


### PR DESCRIPTION
## Summary
- Remove stale Scan API references from `.env.example`, provider-configuration, and error-handling docs
- Fix Go version badge (1.22→1.24), tighten README to point to MkDocs site
- Update release notes to reflect actual 7 resources + 3 data sources
- Fix CSS badge selectors (were Node/TS template leftovers)
- Add `.gitignore` entries for delve debug binaries and `.terraform.lock.hcl`
- Remove empty `docs/examples/` directory

## Test plan
- [x] `mkdocs build --strict` passes
- [x] `go vet ./...` passes
- [x] All 7 resources and 3 data sources have matching doc pages
- [x] CI workflows validate lint/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)