### PR TITLE
fix: state consistency bugs in security profile resource

### DIFF
--- a/docs/resources/security-profile.md
+++ b/docs/resources/security-profile.md
@@ -21,7 +21,7 @@ resource "prisma-airs_security_profile" "basic" {
 }
 ```
 
-### Full — Multiple Protections with Toxic Content Categories
+### Full — Multiple Protections with Data Leak Detection
 
 ```hcl
 resource "prisma-airs_security_profile" "full" {
@@ -31,8 +31,8 @@ resource "prisma-airs_security_profile" "full" {
     model_type = "default"
 
     latency {
-      inline_timeout_action = "allow"
-      max_inline_latency    = 30
+      inline_timeout_action = "block"
+      max_inline_latency    = 25
     }
 
     model_protection {
@@ -42,56 +42,21 @@ resource "prisma-airs_security_profile" "full" {
 
     model_protection {
       name   = "toxic-content"
-      action = "alert"
-
-      toxic_category {
-        category = "harassment"
-        action   = "block"
-      }
-
-      toxic_category {
-        category = "violence"
-        action   = "block"
-      }
-
-      toxic_category {
-        category = "hate-speech"
-        action   = "block"
-      }
-
-      toxic_category {
-        category = "sexual-content"
-        action   = "alert"
-      }
-    }
-
-    model_protection {
-      name   = "url-filtering"
-      action = "alert"
-    }
-
-    model_protection {
-      name   = "malicious-url"
       action = "block"
     }
 
     agent_protection {
-      name   = "agent-threat"
+      name   = "agent-security"
       action = "block"
-    }
-
-    app_protection {
-      block_url_category = ["malware", "phishing"]
-      alert_url_category = ["news", "social-media"]
     }
 
     data_protection {
       data_leak_detection {
-        action         = "block"
+        action           = "block"
         mask_data_inline = true
 
         member {
-          text = "SSN Pattern"
+          text = "sensitive content"
         }
       }
     }
@@ -111,13 +76,28 @@ resource "prisma-airs_security_profile" "topics" {
     model_protection {
       name   = "prompt-injection"
       action = "block"
+    }
+
+    model_protection {
+      name   = "topic-guardrails"
+      action = "allow"
+
+      topic_list {
+        action = "allow"
+
+        topic {
+          topic_name = "Recipe Generation"
+          topic_id   = prisma-airs_custom_topic.recipes.topic_id
+          revision   = 1
+        }
+      }
 
       topic_list {
         action = "block"
 
         topic {
-          topic_name = "proprietary-data"
-          topic_id   = prisma-airs_custom_topic.proprietary.topic_id
+          topic_name = "Restricted Content"
+          topic_id   = prisma-airs_custom_topic.restricted.topic_id
           revision   = 1
         }
       }
@@ -140,24 +120,24 @@ resource "prisma-airs_security_profile" "topics" {
 
 ### `latency` Block (inside `ai_security_profile`)
 
-- `inline_timeout_action` - (Optional) Action on inline timeout (`"allow"` or `"block"`).
+- `inline_timeout_action` - (Optional) Action on inline timeout: `"allow"` or `"block"`.
 - `max_inline_latency` - (Optional) Maximum inline latency in seconds.
 
 ### `model_protection` Block (inside `ai_security_profile`)
 
-- `name` - (Required) Protection name. Values: `"prompt-injection"`, `"toxic-content"`, `"url-filtering"`, `"malicious-url"`.
-- `action` - (Required) Action to take: `"block"`, `"alert"`, or `"allow"`.
+- `name` - (Required) Protection name. Values: `"prompt-injection"`, `"toxic-content"`, `"contextual-grounding"`, `"topic-guardrails"`.
+- `action` - (Required) Action to take: `"block"` or `"allow"`.
 
 ### `toxic_category` Block (inside `model_protection`)
 
 Per-category overrides for toxic content detection.
 
 - `category` - (Required) Category name: `"harassment"`, `"violence"`, `"hate-speech"`, `"sexual-content"`.
-- `action` - (Required) Action for this category.
+- `action` - (Required) Action for this category: `"block"` or `"allow"`.
 
 ### `topic_list` Block (inside `model_protection`)
 
-- `action` - (Required) Action for matched topics.
+- `action` - (Required) Action for matched topics: `"block"` or `"allow"`.
 
 ### `topic` Block (inside `topic_list`)
 
@@ -167,14 +147,13 @@ Per-category overrides for toxic content detection.
 
 ### `agent_protection` Block (inside `ai_security_profile`)
 
-- `name` - (Required) Protection name.
-- `action` - (Required) Action to take.
+- `name` - (Required) Protection name (e.g., `"agent-security"`).
+- `action` - (Required) Action to take: `"block"` or `"allow"`.
 
 ### `app_protection` Block (inside `ai_security_profile`)
 
-- `alert_url_category` - (Optional) List of URL categories to alert on.
-- `block_url_category` - (Optional) List of URL categories to block.
 - `allow_url_category` - (Optional) List of URL categories to allow.
+- `block_url_category` - (Optional) List of URL categories to block.
 
 ### `data_protection` Block (inside `ai_security_profile`)
 
@@ -182,7 +161,7 @@ Contains a `data_leak_detection` sub-block.
 
 ### `data_leak_detection` Block (inside `data_protection`)
 
-- `action` - (Optional) Action on detection: `"block"`, `"alert"`, `"allow"`.
+- `action` - (Optional) Action on detection: `"block"` or `"allow"`.
 - `mask_data_inline` - (Optional) Whether to mask detected data inline.
 
 ### `member` Block (inside `data_leak_detection`)

--- a/examples/sandbox/management.tf
+++ b/examples/sandbox/management.tf
@@ -1,0 +1,92 @@
+# ---------------------------------------------------------------------------
+# Management API — Resources
+# ---------------------------------------------------------------------------
+
+# --- Security Profile ---
+# Configures AI security detection with latency, prompt injection,
+# toxic content detection, agent protection, and data leak detection.
+resource "prisma-airs_security_profile" "main" {
+  profile_name = "sandbox-profile"
+
+  ai_security_profile {
+    model_type = "default"
+
+    latency {
+      inline_timeout_action = "block"
+      max_inline_latency    = 25
+    }
+
+    model_protection {
+      name   = "prompt-injection"
+      action = "block"
+    }
+
+    model_protection {
+      name   = "toxic-content"
+      action = "block"
+    }
+
+    agent_protection {
+      name   = "agent-security"
+      action = "block"
+    }
+
+    data_protection {
+      data_leak_detection {
+        action           = "block"
+        mask_data_inline = true
+
+        member {
+          text = "sensitive content"
+        }
+      }
+    }
+  }
+}
+
+# --- Custom Topic ---
+# Defines a custom content detection topic with training examples.
+resource "prisma-airs_custom_topic" "main" {
+  topic_name  = "sandbox-topic"
+  description = "Custom topic for detecting proprietary content"
+  examples = [
+    "Our Q4 revenue projections show significant growth in the APAC region.",
+    "The internal product roadmap includes a new AI-powered feature launch in September.",
+    "Employee stock option vesting schedules are outlined in section 4.2 of the handbook.",
+  ]
+}
+
+# --- Customer App ---
+# Registers an application that will use AI Runtime Security.
+resource "prisma-airs_customer_app" "main" {
+  app_name       = "sandbox-app"
+  model_name     = "gpt-4"
+  cloud_provider = "AWS"
+  environment    = "development"
+}
+
+# --- API Key ---
+# Creates an API key for the registered app.
+# Requires a valid auth_code from a deployment profile.
+# Uncomment after you have a deployment profile auth code.
+#
+# resource "prisma-airs_api_key" "main" {
+#   api_key_name           = "sandbox-key"
+#   auth_code              = data.prisma-airs_deployment_profiles.all.items[0].auth_code
+#   cust_app               = prisma-airs_customer_app.main.app_name
+#   created_by             = "terraform-sandbox"
+#   rotation_time_interval = 90
+#   rotation_time_unit     = "days"
+# }
+
+# ---------------------------------------------------------------------------
+# Management API — Data Sources
+# ---------------------------------------------------------------------------
+
+data "prisma-airs_dlp_profiles" "all" {
+  limit = 50
+}
+
+data "prisma-airs_deployment_profiles" "all" {
+  limit = 50
+}

--- a/internal/provider/resource_security_profile.go
+++ b/internal/provider/resource_security_profile.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -147,14 +148,23 @@ func (r *securityProfileResource) Schema(_ context.Context, _ resource.SchemaReq
 			"active": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Whether the profile is active.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_at": schema.StringAttribute{
 				Computed:    true,
 				Description: "Creation timestamp.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				Computed:    true,
 				Description: "Last update timestamp.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -641,13 +651,17 @@ func mapProfileToState(ctx context.Context, profile *management.SecurityProfile,
 	state.AiSecurityProfiles = nil
 	for _, asp := range profile.Policy.AiSecurityProfiles {
 		model := AiSecurityProfileModel{
-			ModelType:   types.StringValue(asp.ModelType),
-			ContentType: types.StringValue(asp.ContentType),
+			ModelType: types.StringValue(asp.ModelType),
+		}
+		if asp.ContentType != "" {
+			model.ContentType = types.StringValue(asp.ContentType)
 		}
 
 		if asp.ModelConfiguration != nil {
 			mc := asp.ModelConfiguration
-			model.MaskDataInStorage = types.BoolValue(mc.MaskDataInStorage)
+			if mc.MaskDataInStorage {
+				model.MaskDataInStorage = types.BoolValue(true)
+			}
 
 			if mc.Latency != nil {
 				model.Latency = &LatencyModel{
@@ -663,11 +677,16 @@ func mapProfileToState(ctx context.Context, profile *management.SecurityProfile,
 					MaskDataInline: types.BoolValue(dld.MaskDataInline),
 				}
 				for _, m := range dld.Member {
-					dldModel.Members = append(dldModel.Members, DataLeakMemberModel{
-						Text:    types.StringValue(m.Text),
-						ID:      types.StringValue(m.ID),
-						Version: types.StringValue(m.Version),
-					})
+					member := DataLeakMemberModel{
+						Text: types.StringValue(m.Text),
+					}
+					if m.ID != "" {
+						member.ID = types.StringValue(m.ID)
+					}
+					if m.Version != "" {
+						member.Version = types.StringValue(m.Version)
+					}
+					dldModel.Members = append(dldModel.Members, member)
 				}
 				model.DataProtection = &DataProtectionModel{
 					DataLeakDetection: dldModel,


### PR DESCRIPTION
## Summary

- Fix null-vs-zero-value inconsistencies causing "Provider produced inconsistent result after apply" errors
- Add `UseStateForUnknown` plan modifiers for `active`, `created_at`, `updated_at` to eliminate plan churn
- Update sandbox example and docs to use real API-validated config (block/allow, not alert)

## Bugs Fixed

| Field | Was | Now |
|-------|-----|-----|
| `content_type` | `null → ""` crash | stays null when empty |
| `mask_data_in_storage` | `null → false` crash | stays null when false |
| `member.id` / `member.version` | `null → ""` drift | stays null when empty |
| `active` / `created_at` / `updated_at` | `value → (known after apply)` churn | preserves state |

## Test plan

- [x] `make check` passes (fmt, vet, lint, test)
- [x] E2E: Create → Read (no drift) → Import → Read (no drift) → Delete — all pass
- [x] E2E validated with real API-derived config (block/allow actions)

Closes #24