### PR TITLE
fix: purge stale jsonencode examples, align docs with HCL schema

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.1"
+      version = "~> 0.3"
     }
   }
 }
@@ -32,28 +32,24 @@ provider "prisma-airs" {}
 resource "prisma-airs_security_profile" "example" {
   profile_name = "my-ai-security-profile"
 
-  policy = jsonencode({
-    ai-security-profiles = [{
-      latency-config = {
-        inline-timeout-action = "allow"
-        max-inline-latency    = 5000
-      }
-      model-protection = {
-        prompt-injection = {
-          action = "block"
-        }
-        toxic-content = {
-          action        = "alert"
-          toxic-category-list = [
-            { category = "profanity", threshold = "low" }
-          ]
-        }
-        url-filtering = {
-          action = "alert"
-        }
-      }
-    }]
-  })
+  ai_security_profile {
+    model_type = "default"
+
+    latency {
+      inline_timeout_action = "block"
+      max_inline_latency    = 30
+    }
+
+    model_protection {
+      name   = "prompt-injection"
+      action = "block"
+    }
+
+    model_protection {
+      name   = "toxic-content"
+      action = "high:block, moderate:allow"
+    }
+  }
 }
 ```
 
@@ -69,13 +65,23 @@ terraform apply
 
 ```hcl
 resource "prisma-airs_red_team_target" "my_app" {
-  name        = "my-ai-application"
-  target_type = "APPLICATION"
+  name            = "my-ai-application"
+  target_type     = "APPLICATION"
+  connection_type = "REST"
 
-  connection = {
-    type     = "REST"
-    endpoint = "https://my-app.example.com/api/chat"
-  }
+  connection_params = jsonencode({
+    url = "https://my-app.example.com/api/chat"
+    headers = {
+      "Content-Type" = "application/json"
+    }
+    request_json = {
+      prompt = "{INPUT}"
+    }
+    response_json = {
+      output = "{RESPONSE}"
+    }
+    response_key = "output"
+  })
 }
 ```
 

--- a/docs/guides/managing-security-profiles.md
+++ b/docs/guides/managing-security-profiles.md
@@ -8,29 +8,40 @@ This guide walks through managing AI security profiles with the Prisma AIRS Terr
 resource "prisma-airs_security_profile" "production" {
   profile_name = "production-ai-security"
 
-  policy = jsonencode({
-    ai-security-profiles = [{
-      latency-config = {
-        inline-timeout-action = "allow"
-        max-inline-latency    = 5000
+  ai_security_profile {
+    model_type = "default"
+
+    latency {
+      inline_timeout_action = "block"
+      max_inline_latency    = 30
+    }
+
+    model_protection {
+      name   = "prompt-injection"
+      action = "block"
+    }
+
+    model_protection {
+      name   = "toxic-content"
+      action = "high:block, moderate:block"
+    }
+
+    agent_protection {
+      name   = "agent-security"
+      action = "block"
+    }
+
+    data_protection {
+      data_leak_detection {
+        action           = "block"
+        mask_data_inline = true
+
+        member {
+          text = "sensitive content"
+        }
       }
-      model-protection = {
-        prompt-injection = {
-          action = "block"
-        }
-        toxic-content = {
-          action = "block"
-          toxic-category-list = [
-            { category = "profanity", threshold = "low" },
-            { category = "hate-speech", threshold = "low" }
-          ]
-        }
-        url-filtering = {
-          action = "alert"
-        }
-      }
-    }]
-  })
+    }
+  }
 }
 ```
 
@@ -52,12 +63,29 @@ resource "prisma-airs_custom_topic" "financial" {
 resource "prisma-airs_security_profile" "with_topics" {
   profile_name = "finance-team-profile"
 
-  policy = jsonencode({
-    topic_violation = {
+  ai_security_profile {
+    model_type = "default"
+
+    model_protection {
+      name   = "prompt-injection"
       action = "block"
-      topics = [prisma-airs_custom_topic.financial.topic_id]
     }
-  })
+
+    model_protection {
+      name   = "topic-guardrails"
+      action = "block"
+
+      topic_list {
+        action = "block"
+
+        topic {
+          topic_name = prisma-airs_custom_topic.financial.topic_name
+          topic_id   = prisma-airs_custom_topic.financial.topic_id
+          revision   = 1
+        }
+      }
+    }
+  }
 }
 ```
 

--- a/docs/guides/red-team-testing.md
+++ b/docs/guides/red-team-testing.md
@@ -6,17 +6,24 @@ This guide covers managing red team targets and custom prompt sets with the Pris
 
 ```hcl
 resource "prisma-airs_red_team_target" "chatbot" {
-  name        = "customer-chatbot"
-  target_type = "APPLICATION"
-  description = "Customer-facing chatbot application"
+  name            = "customer-chatbot"
+  target_type     = "APPLICATION"
+  description     = "Customer-facing chatbot application"
+  connection_type = "REST"
 
-  connection = jsonencode({
-    type     = "REST"
-    endpoint = "https://chatbot.example.com/api/chat"
+  connection_params = jsonencode({
+    url = "https://chatbot.example.com/api/chat"
     headers = {
       "Authorization" = "Bearer ${var.chatbot_api_key}"
       "Content-Type"  = "application/json"
     }
+    request_json = {
+      prompt = "{INPUT}"
+    }
+    response_json = {
+      output = "{RESPONSE}"
+    }
+    response_key = "output"
   })
 }
 ```

--- a/docs/resources/red-team-target.md
+++ b/docs/resources/red-team-target.md
@@ -6,16 +6,24 @@ Manages a red team target in Prisma AIRS Red Team API.
 
 ```hcl
 resource "prisma-airs_red_team_target" "my_app" {
-  name        = "production-chatbot"
-  target_type = "APPLICATION"
-  description = "Production customer-facing chatbot"
+  name            = "production-chatbot"
+  target_type     = "APPLICATION"
+  description     = "Production customer-facing chatbot"
+  connection_type = "REST"
 
-  connection = jsonencode({
-    type     = "REST"
-    endpoint = "https://my-app.example.com/api/chat"
+  connection_params = jsonencode({
+    url = "https://my-app.example.com/api/chat"
     headers = {
       "Authorization" = "Bearer ${var.app_token}"
+      "Content-Type"  = "application/json"
     }
+    request_json = {
+      prompt = "{INPUT}"
+    }
+    response_json = {
+      output = "{RESPONSE}"
+    }
+    response_key = "output"
   })
 }
 ```
@@ -23,10 +31,10 @@ resource "prisma-airs_red_team_target" "my_app" {
 ## Argument Reference
 
 - `name` - (Required) Name of the target.
-- `target_type` - (Required) Type of target. Valid values: `APPLICATION`, `AGENT`, `MODEL`.
+- `target_type` - (Optional) Type of target: `APPLICATION`, `AGENT`, `MODEL`.
 - `description` - (Optional) Description of the target.
-- `connection` - (Required) JSON-encoded connection configuration.
-- `validate` - (Optional) Whether to validate the target connection on create/update. Default: `true`.
+- `connection_type` - (Optional) Connection type: `REST`, `STREAMING`, `OPENAI`, `BEDROCK`, `DATABRICKS`, `HUGGING_FACE`, `CUSTOM`.
+- `connection_params` - (Optional, Sensitive) JSON-encoded connection parameters.
 
 ## Attribute Reference
 

--- a/e2e/management.tf
+++ b/e2e/management.tf
@@ -6,37 +6,24 @@
 resource "prisma-airs_security_profile" "test" {
   profile_name = "${local.prefix}-profile"
 
-  policy = jsonencode({
-    "ai-security-profiles" = [
-      {
-        "model-type" = "default"
-        "model-configuration" = {
-          "latency" = {
-            "inline-timeout-action" = "allow"
-            "max-inline-latency"    = 30
-          }
-          "model-protection" = [
-            {
-              name   = "prompt-injection"
-              action = "alert"
-            },
-            {
-              name   = "url-filtering"
-              action = "alert"
-            },
-            {
-              name   = "toxic-content"
-              action = "alert"
-              "toxic-category-list" = [
-                { category = "harassment", action = "alert" },
-                { category = "violence", action = "alert" }
-              ]
-            }
-          ]
-        }
-      }
-    ]
-  })
+  ai_security_profile {
+    model_type = "default"
+
+    latency {
+      inline_timeout_action = "block"
+      max_inline_latency    = 30
+    }
+
+    model_protection {
+      name   = "prompt-injection"
+      action = "block"
+    }
+
+    model_protection {
+      name   = "toxic-content"
+      action = "block"
+    }
+  }
 }
 
 # --- Custom Topic ---

--- a/examples/resources/security_profile/main.tf
+++ b/examples/resources/security_profile/main.tf
@@ -1,31 +1,38 @@
 resource "prisma-airs_security_profile" "example" {
   profile_name = "example-profile"
 
-  policy = jsonencode({
-    "ai-security-profiles" = [
-      {
-        "model-type" = "default"
-        "model-configuration" = {
-          "latency" = {
-            "inline-timeout-action" = "allow"
-            "max-inline-latency"    = 30
-          }
-          "model-protection" = [
-            {
-              name   = "prompt-injection"
-              action = "block"
-            },
-            {
-              name   = "toxic-content"
-              action = "alert"
-              "toxic-category-list" = [
-                { category = "harassment", action = "alert" },
-                { category = "violence", action = "block" }
-              ]
-            }
-          ]
+  ai_security_profile {
+    model_type = "default"
+
+    latency {
+      inline_timeout_action = "block"
+      max_inline_latency    = 30
+    }
+
+    model_protection {
+      name   = "prompt-injection"
+      action = "block"
+    }
+
+    model_protection {
+      name   = "toxic-content"
+      action = "high:block, moderate:allow"
+    }
+
+    agent_protection {
+      name   = "agent-security"
+      action = "block"
+    }
+
+    data_protection {
+      data_leak_detection {
+        action           = "block"
+        mask_data_inline = true
+
+        member {
+          text = "sensitive content"
         }
       }
-    ]
-  })
+    }
+  }
 }

--- a/examples/sandbox/.gitignore
+++ b/examples/sandbox/.gitignore
@@ -1,0 +1,5 @@
+.dev.tfrc
+terraform.tfstate
+terraform.tfstate.backup
+.terraform/
+.terraform.lock.hcl

--- a/examples/sandbox/main.tf
+++ b/examples/sandbox/main.tf
@@ -1,0 +1,35 @@
+# ---------------------------------------------------------------------------
+# Prisma AIRS Provider — Sandbox
+# ---------------------------------------------------------------------------
+# Interactive Terraform project for manually testing all resources and
+# data sources. Use standard terraform commands:
+#
+#   terraform plan
+#   terraform apply
+#   terraform destroy
+#
+# Prerequisites:
+#   1. Build the provider:  make build
+#   2. Export credentials:
+#        export PANW_MGMT_CLIENT_ID="..."
+#        export PANW_MGMT_CLIENT_SECRET="..."
+#        export PANW_MGMT_TSG_ID="..."
+#      Or source the repo's .env file (see below).
+# ---------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    prisma-airs = {
+      source = "cdot65/prisma-airs"
+    }
+  }
+}
+
+# Provider configured via environment variables.
+# Override inline if you prefer:
+#   provider "prisma-airs" {
+#     client_id     = "..."
+#     client_secret = "..."
+#     tsg_id        = "..."
+#   }
+provider "prisma-airs" {}

--- a/examples/sandbox/model_security.tf
+++ b/examples/sandbox/model_security.tf
@@ -1,0 +1,17 @@
+# ---------------------------------------------------------------------------
+# Model Security — Resources
+# ---------------------------------------------------------------------------
+
+# --- Security Group ---
+# Creates a model security group for monitoring AI models.
+resource "prisma-airs_model_security_group" "main" {
+  name        = "sandbox-group"
+  description = "Security group for monitoring Hugging Face models"
+  source_type = "HUGGING_FACE"
+}
+
+# ---------------------------------------------------------------------------
+# Model Security — Data Sources
+# ---------------------------------------------------------------------------
+
+data "prisma-airs_model_security_rules" "all" {}

--- a/examples/sandbox/outputs.tf
+++ b/examples/sandbox/outputs.tf
@@ -1,0 +1,77 @@
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+# ── Management ─────────────────────────────────────────────────────────────
+
+output "security_profile" {
+  description = "Security profile details"
+  value = {
+    id     = prisma-airs_security_profile.main.profile_id
+    name   = prisma-airs_security_profile.main.profile_name
+    active = prisma-airs_security_profile.main.active
+  }
+}
+
+output "custom_topic" {
+  description = "Custom topic details"
+  value = {
+    id   = prisma-airs_custom_topic.main.topic_id
+    name = prisma-airs_custom_topic.main.topic_name
+  }
+}
+
+output "customer_app" {
+  description = "Customer app details"
+  value = {
+    id     = prisma-airs_customer_app.main.customer_app_id
+    name   = prisma-airs_customer_app.main.app_name
+    status = prisma-airs_customer_app.main.status
+  }
+}
+
+output "dlp_profiles" {
+  description = "Available DLP profiles"
+  value       = [for p in data.prisma-airs_dlp_profiles.all.items : p.profile_name]
+}
+
+output "deployment_profiles" {
+  description = "Available deployment profiles"
+  value       = [for p in data.prisma-airs_deployment_profiles.all.items : p.profile_name]
+}
+
+# ── Model Security ─────────────────────────────────────────────────────────
+
+output "model_security_group" {
+  description = "Model security group details"
+  value = {
+    id    = prisma-airs_model_security_group.main.uuid
+    name  = prisma-airs_model_security_group.main.name
+    state = prisma-airs_model_security_group.main.state
+  }
+}
+
+output "model_security_rule_count" {
+  description = "Number of model security rules"
+  value       = length(data.prisma-airs_model_security_rules.all.rules)
+}
+
+# ── Red Team ───────────────────────────────────────────────────────────────
+
+output "red_team_prompt_set" {
+  description = "Red team custom prompt set details"
+  value = {
+    id     = prisma-airs_red_team_custom_prompt_set.main.uuid
+    name   = prisma-airs_red_team_custom_prompt_set.main.name
+    status = prisma-airs_red_team_custom_prompt_set.main.status
+  }
+}
+
+output "red_team_target" {
+  description = "Red team target details"
+  value = {
+    id     = prisma-airs_red_team_target.main.uuid
+    name   = prisma-airs_red_team_target.main.name
+    status = prisma-airs_red_team_target.main.status
+  }
+}

--- a/examples/sandbox/red_team.tf
+++ b/examples/sandbox/red_team.tf
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------
+# Red Team — Resources
+# ---------------------------------------------------------------------------
+
+# --- Custom Prompt Set ---
+# Creates a custom prompt set for red team testing.
+resource "prisma-airs_red_team_custom_prompt_set" "main" {
+  name        = "sandbox-prompts"
+  description = "Custom prompt set for adversarial testing"
+}
+
+# --- Target ---
+# Registers an AI application as a red team testing target.
+# Uses httpbin as a safe public endpoint for testing.
+resource "prisma-airs_red_team_target" "main" {
+  name            = "sandbox-target"
+  description     = "Test target using httpbin echo service"
+  target_type     = "APPLICATION"
+  connection_type = "REST"
+
+  connection_params = jsonencode({
+    url = "https://httpbin.org/post"
+    headers = {
+      "Content-Type" = "application/json"
+    }
+    request_json = {
+      prompt = "{INPUT}"
+    }
+    response_json = {
+      output = "{RESPONSE}"
+    }
+    response_key = "output"
+  })
+}

--- a/examples/sandbox/setup.sh
+++ b/examples/sandbox/setup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Sandbox setup — build provider and configure dev_overrides
+# ---------------------------------------------------------------------------
+# Run this once before using terraform plan/apply/destroy:
+#   source ./setup.sh
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SANDBOX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Building provider..."
+cd "$REPO_ROOT"
+make build
+
+# Create dev_overrides config
+cat > "$SANDBOX_DIR/.dev.tfrc" <<EOF
+provider_installation {
+  dev_overrides {
+    "cdot65/prisma-airs" = "$REPO_ROOT"
+  }
+  direct {}
+}
+EOF
+
+export TF_CLI_CONFIG_FILE="$SANDBOX_DIR/.dev.tfrc"
+
+# Load credentials from .env if available
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  echo "Loading credentials from .env"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# || ! "$line" =~ = ]] && continue
+    export "$line"
+  done < "$REPO_ROOT/.env"
+fi
+
+cd "$SANDBOX_DIR"
+echo ""
+echo "Ready! You can now run:"
+echo "  terraform plan"
+echo "  terraform apply"
+echo "  terraform destroy"
+echo ""
+echo "TF_CLI_CONFIG_FILE=$TF_CLI_CONFIG_FILE"


### PR DESCRIPTION
## Summary

- Replace all `policy = jsonencode(...)` with native HCL blocks in docs, examples, and e2e tests
- Fix `connection = jsonencode(...)` → `connection_type` + `connection_params = jsonencode(...)` in red team docs
- Fix `p.name` → `p.profile_name` in sandbox DLP output
- Remove all stale `alert` action values from examples
- Add sandbox example files to version control

## Test plan

- [x] `make check` passes (fmt/vet/lint/test)
- [x] `mkdocs build --strict` passes
- [x] Zero `policy = jsonencode` in repo (verified via grep)
- [x] Zero `connection = jsonencode` in repo (verified via grep)
- [x] Zero `alert` in `.tf`/`.md` files (except SDK reference notes)
- [x] Sandbox E2E: plan succeeded (6 resources), apply created 5/6 (customer_app API timeout — pre-existing), destroy cleaned 4/5 (topic ForceDelete API timeout — pre-existing)

Closes #30