### PR TITLE
docs: fix stale versions, add release notes, add output examples

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## v0.3.2 — Fix Profile ID Revision Handling
+
+- Fix: handle API revision model that changes `profile_id` on update
+- Profile reads now reconcile server-assigned IDs after update operations
+
+## v0.3.1 — State Consistency Fixes
+
+- Fix: state consistency bugs in security profile resource
+- Ensure Terraform state stays in sync with API after create/update
+
+## v0.3.0 — SDK v0.2.0, GetByID/GetByName Lookups
+
+- Refactor: use SDK v0.2.0 `GetByID`/`GetByName` for profile lookups
+- Upgrade `prisma-airs-go` SDK to v0.2.0
+
+## v0.2.0 — Native HCL Security Profile Schema
+
+- **Breaking:** replace `policy = jsonencode(...)` with native HCL blocks (`ai_security_profile`, `model_protection`, `agent_protection`, `data_protection`)
+- Security profiles now use typed nested blocks instead of opaque JSON strings
+- Enables Terraform plan diffs, validation, and auto-complete for all profile fields
+
 ## v0.1.0 — Initial Release
 
 ### Resources (7)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.1"
+      version = "~> 0.3"
     }
   }
 }
@@ -45,7 +45,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.1"
+      version = "~> 0.3"
     }
   }
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -61,6 +61,60 @@ terraform plan
 terraform apply
 ```
 
+#### Sample `terraform plan` output
+
+```
+Terraform will perform the following actions:
+
+  # prisma-airs_security_profile.example will be created
+  + resource "prisma-airs_security_profile" "example" {
+      + active       = (known after apply)
+      + id           = (known after apply)
+      + profile_id   = (known after apply)
+      + profile_name = "my-ai-security-profile"
+      + profile_type = (known after apply)
+      + updated_by   = (known after apply)
+
+      + ai_security_profile {
+          + model_type = "default"
+
+          + latency {
+              + inline_timeout_action = "block"
+              + max_inline_latency    = 30
+            }
+
+          + model_protection {
+              + action = "block"
+              + name   = "prompt-injection"
+            }
+          + model_protection {
+              + action = "high:block, moderate:allow"
+              + name   = "toxic-content"
+            }
+        }
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+```
+
+#### Sample `terraform apply` output
+
+```
+prisma-airs_security_profile.example: Creating...
+prisma-airs_security_profile.example: Creation complete after 2s [id=abcd1234-5678-90ef-ghij-klmnopqrstuv]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+```
+
+#### Sample `terraform destroy` output
+
+```
+prisma-airs_security_profile.example: Destroying... [id=abcd1234-5678-90ef-ghij-klmnopqrstuv]
+prisma-airs_security_profile.example: Destruction complete after 2s
+
+Destroy complete! Resources: 1 destroyed.
+```
+
 ## Example: Create a Red Team Target
 
 ```hcl


### PR DESCRIPTION
## Summary

- Fix `installation.md` version pins from `~> 0.1` to `~> 0.3`
- Add release notes for v0.2.0, v0.3.0, v0.3.1, v0.3.2
- Add sample `terraform plan`/`apply`/`destroy` output to quick-start guide

Closes #32