### PR TITLE
docs: comprehensive audit fixes, align all docs with Go schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.1"
+      version = "~> 0.4"
     }
   }
 }

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## v0.4.0 — SDK v0.2.1, ForceDelete, Schema Validators, Doc Overhaul
+
+- Upgrade `prisma-airs-go` SDK to v0.2.1
+- Use `ForceDelete` for security profile and custom topic deletion (removes JSON parse workaround)
+- Add `ToxicContentAction` compound values for toxic-content model protection (`high:block, moderate:allow`, etc.)
+- Add schema validation via `stringvalidator.OneOf` for all protection names and actions
+- Add `terraform-plugin-framework-validators` dependency
+- Comprehensive documentation audit: fix all resource/data source docs to match Go schemas
+- Fix API key docs: add missing required fields (`auth_code`, `rotation_time_interval`, `rotation_time_unit`)
+- Fix model security rules docs: remove non-existent filter arguments, correct attribute name (`rules` not `items`)
+- Fix deployment profiles docs: add missing `auth_code` attribute
+- Fix red team custom prompt set docs: add missing `properties`, `status`, `active`, `archive` attributes
+- Fix security profile docs: add `alert_url_category` to app_protection reference
+- Update all version references to `~> 0.4`
+
 ## v0.3.2 — Fix Profile ID Revision Handling
 
 - Fix: handle API revision model that changes `profile_id` on update

--- a/docs/data-sources/deployment-profiles.md
+++ b/docs/data-sources/deployment-profiles.md
@@ -5,10 +5,12 @@ Reads deployment profiles from Prisma AIRS Management API.
 ## Example Usage
 
 ```hcl
-data "prisma-airs_deployment_profiles" "all" {}
+data "prisma-airs_deployment_profiles" "all" {
+  limit = 10
+}
 
 output "profiles" {
-  value = data.prisma-airs_deployment_profiles.all.items
+  value = [for p in data.prisma-airs_deployment_profiles.all.items : p.profile_name]
 }
 ```
 
@@ -20,7 +22,8 @@ output "profiles" {
 ## Attribute Reference
 
 - `items` - List of deployment profiles. Each item contains:
-    - `profile_id` - Profile ID.
-    - `profile_name` - Profile name.
-    - `details` - Profile details (JSON).
-- `total_count` - Total number of profiles.
+    - `profile_id` - Deployment profile ID (same value as `auth_code`).
+    - `profile_name` - Deployment profile name.
+    - `auth_code` - Auth code for API key creation.
+    - `details` - Full profile details as a JSON string.
+- `total_count` - Number of profiles returned.

--- a/docs/data-sources/model-security-rules.md
+++ b/docs/data-sources/model-security-rules.md
@@ -1,31 +1,31 @@
 # prisma-airs_model_security_rules
 
-Reads model security rules from Prisma AIRS Model Security API.
+Reads the catalog of model security rules from Prisma AIRS Model Security API. Returns all available rules — no filter parameters are accepted.
 
 ## Example Usage
 
 ```hcl
 data "prisma-airs_model_security_rules" "all" {}
 
-data "prisma-airs_model_security_rules" "huggingface" {
-  source_type = "HUGGING_FACE"
+output "rule_count" {
+  value = length(data.prisma-airs_model_security_rules.all.rules)
+}
+
+output "rule_names" {
+  value = [for r in data.prisma-airs_model_security_rules.all.rules : r.name]
 }
 ```
 
 ## Argument Reference
 
-- `limit` - (Optional) Maximum number of rules to return.
-- `skip` - (Optional) Number of rules to skip.
-- `source_type` - (Optional) Filter by source type.
-- `search_query` - (Optional) Search query string.
+This data source takes no arguments.
 
 ## Attribute Reference
 
-- `items` - List of security rules. Each item contains:
+- `rules` - List of security rules. Each item contains:
     - `uuid` - Rule UUID.
     - `name` - Rule name.
     - `description` - Rule description.
-    - `source_type` - Source type.
+    - `source_type` - Compatible source types (comma-separated).
     - `rule_type` - Rule type (`METADATA`, `ARTIFACT`).
-    - `created_at` - Timestamp.
-- `total` - Total number of rules.
+    - `created_at` - Creation timestamp.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.3"
+      version = "~> 0.4"
     }
   }
 }
@@ -45,7 +45,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.3"
+      version = "~> 0.4"
     }
   }
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.3"
+      version = "~> 0.4"
     }
   }
 }
@@ -69,11 +69,11 @@ Terraform will perform the following actions:
   # prisma-airs_security_profile.example will be created
   + resource "prisma-airs_security_profile" "example" {
       + active       = (known after apply)
+      + created_at   = (known after apply)
       + id           = (known after apply)
       + profile_id   = (known after apply)
       + profile_name = "my-ai-security-profile"
-      + profile_type = (known after apply)
-      + updated_by   = (known after apply)
+      + updated_at   = (known after apply)
 
       + ai_security_profile {
           + model_type = "default"

--- a/docs/guides/managing-security-profiles.md
+++ b/docs/guides/managing-security-profiles.md
@@ -91,10 +91,19 @@ resource "prisma-airs_security_profile" "with_topics" {
 
 ## Managing API Keys
 
+API keys require a deployment profile auth code, a rotation interval, and a rotation time unit:
+
 ```hcl
+data "prisma-airs_deployment_profiles" "all" {
+  limit = 10
+}
+
 resource "prisma-airs_api_key" "scanner" {
-  api_key_name = "production-scanner-key"
-  created_by   = "terraform"
+  api_key_name           = "production-scanner-key"
+  auth_code              = data.prisma-airs_deployment_profiles.all.items[0].auth_code
+  rotation_time_interval = 90
+  rotation_time_unit     = "days"
+  created_by             = "terraform"
 }
 
 output "api_key_value" {

--- a/docs/resources/api-key.md
+++ b/docs/resources/api-key.md
@@ -5,15 +5,26 @@ Manages an API key for AI Runtime Security scanning in Prisma AIRS.
 ## Example Usage
 
 ```hcl
+data "prisma-airs_deployment_profiles" "all" {
+  limit = 10
+}
+
 resource "prisma-airs_api_key" "scanner" {
-  api_key_name = "production-scanner"
-  created_by   = "terraform"
+  api_key_name           = "production-scanner"
+  auth_code              = data.prisma-airs_deployment_profiles.all.items[0].auth_code
+  rotation_time_interval = 90
+  rotation_time_unit     = "days"
+  created_by             = "terraform"
 }
 ```
 
 ## Argument Reference
 
 - `api_key_name` - (Required, ForceNew) Name for the API key.
+- `auth_code` - (Required, ForceNew) Deployment profile auth code. Use the `prisma-airs_deployment_profiles` data source to discover available auth codes.
+- `rotation_time_interval` - (Required) Rotation interval value (e.g., `90` for 90 days).
+- `rotation_time_unit` - (Required) Rotation time unit (`days`, `months`).
+- `cust_app` - (Optional) Customer application name to associate with the key.
 - `created_by` - (Optional) Identity of who created the key.
 
 ## Attribute Reference

--- a/docs/resources/red-team-custom-prompt-set.md
+++ b/docs/resources/red-team-custom-prompt-set.md
@@ -15,14 +15,20 @@ resource "prisma-airs_red_team_custom_prompt_set" "injection_tests" {
 
 - `name` - (Required) Name of the prompt set.
 - `description` - (Optional) Description of the prompt set.
+- `properties` - (Optional) Properties as a JSON-encoded string.
 
 ## Attribute Reference
 
 - `id` - The prompt set UUID.
 - `uuid` - The prompt set UUID (same as `id`).
-- `version` - Current version of the prompt set.
+- `status` - Prompt set status.
+- `active` - Whether the prompt set is active.
+- `archive` - Whether the prompt set is archived.
 - `created_at` - Timestamp when the prompt set was created.
 - `updated_at` - Timestamp when the prompt set was last updated.
+
+!!! note
+    Deleting a custom prompt set archives it rather than permanently removing it, as the Red Team API does not support permanent deletion.
 
 ## Import
 

--- a/docs/resources/security-profile.md
+++ b/docs/resources/security-profile.md
@@ -177,6 +177,7 @@ Per-category overrides for toxic content detection.
 
 ### `app_protection` Block (inside `ai_security_profile`)
 
+- `alert_url_category` - (Optional) List of URL categories to alert on.
 - `allow_url_category` - (Optional) List of URL categories to allow.
 - `block_url_category` - (Optional) List of URL categories to block.
 


### PR DESCRIPTION
## Summary

Full documentation audit against Go source schemas. Fixes all inaccuracies found:

- **api-key.md**: add missing required fields (`auth_code`, `rotation_time_interval`, `rotation_time_unit`), update example
- **model-security-rules.md**: remove non-existent filter arguments, correct attribute name (`rules` not `items`)
- **red-team-custom-prompt-set.md**: add missing `properties`, `status`, `active`, `archive` attributes
- **deployment-profiles.md**: add missing `auth_code` attribute, document `profile_id` = `auth_code`
- **security-profile.md**: add `alert_url_category` to app_protection reference
- **quick-start.md**: fix terraform plan output (remove non-existent `profile_type`/`updated_by`, add `created_at`/`updated_at`)
- **managing-security-profiles.md**: fix API key example with all required fields
- **installation.md**, **quick-start.md**: update version to `~> 0.4`
- **README.md**: update version to `~> 0.4`
- **release-notes.md**: add v0.4.0 entry

Closes #34