### PR TITLE
feat: customer_app import-only, upgrade SDK to v0.3.1

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v0.5.0 — Customer App Import-Only, SDK v0.3.1
+
+- **Breaking:** `prisma-airs_customer_app` no longer supports `terraform apply` for new apps — use `terraform import` instead. The AIRS API has no POST endpoint for customer apps; they are created externally.
+- Upgrade `prisma-airs-go` SDK to v0.3.1 (removes `Create`, fixes List endpoint, adds new fields)
+- Add computed attributes: `agent_app`, `ai_sec_profile_name`
+- `tsg_id` is now computed-only (set by the API, not the user)
+- Update docs and sandbox examples to reflect import-only workflow
+
+## v0.4.1 — SDK v0.3.0
+
+- Upgrade `prisma-airs-go` SDK to v0.3.0 (docs/examples only, no API changes)
+
 ## v0.4.0 — SDK v0.2.1, ForceDelete, Schema Validators, Doc Overhaul
 
 - Upgrade `prisma-airs-go` SDK to v0.2.1

--- a/docs/resources/customer-app.md
+++ b/docs/resources/customer-app.md
@@ -1,22 +1,32 @@
 # prisma-airs_customer_app
 
-Manages a customer application registration in Prisma AIRS Management API.
+Manages an existing customer application in Prisma AIRS Management API.
+
+!!! important
+    Customer apps are created externally (via the AIRS console or when applications register themselves). This resource does **not** support `terraform apply` for new apps — use `terraform import` to bring an existing app under Terraform management, then update or delete it.
 
 ## Example Usage
 
+### Import an existing app
+
+```bash
+terraform import prisma-airs_customer_app.chatbot customer-support-chatbot
+```
+
+### Manage the imported app
+
 ```hcl
 resource "prisma-airs_customer_app" "chatbot" {
-  app_name      = "customer-support-chatbot"
-  tsg_id        = "1234567890"
+  app_name       = "customer-support-chatbot"
+  model_name     = "gpt-4"
   cloud_provider = "aws"
-  environment   = "production"
+  environment    = "production"
 }
 ```
 
 ## Argument Reference
 
-- `app_name` - (Required) Name of the customer application.
-- `tsg_id` - (Optional, ForceNew) Tenant service group ID.
+- `app_name` - (Required) Name of the customer application (used as the lookup key).
 - `model_name` - (Optional) Model name associated with the app.
 - `cloud_provider` - (Optional) Cloud provider for the app.
 - `environment` - (Optional) Deployment environment.
@@ -26,13 +36,16 @@ resource "prisma-airs_customer_app" "chatbot" {
 
 - `id` - The application ID.
 - `customer_app_id` - The application ID (same as `id`).
+- `tsg_id` - Tenant service group ID.
 - `status` - App status.
 - `created_by` - Identity of the user who created the app.
+- `agent_app` - Whether this is an agent application.
 - `ai_agent_framework` - AI agent framework.
+- `ai_sec_profile_name` - Associated AI security profile name.
 
 ## Import
 
-Customer apps can be imported using the app name:
+Customer apps are imported by app name:
 
 ```bash
 terraform import prisma-airs_customer_app.chatbot <app_name>

--- a/examples/sandbox/management.tf
+++ b/examples/sandbox/management.tf
@@ -57,13 +57,13 @@ resource "prisma-airs_custom_topic" "main" {
 }
 
 # --- Customer App ---
-# Registers an application that will use AI Runtime Security.
-resource "prisma-airs_customer_app" "main" {
-  app_name       = "sandbox-app"
-  model_name     = "gpt-4"
-  cloud_provider = "AWS"
-  environment    = "development"
-}
+# Customer apps are created externally (AIRS console / app registration).
+# Use `terraform import` to bring an existing app under management:
+#   terraform import prisma-airs_customer_app.main <app_name>
+#
+# resource "prisma-airs_customer_app" "main" {
+#   app_name = "my-existing-app"
+# }
 
 # --- API Key ---
 # Creates an API key for the registered app.

--- a/examples/sandbox/outputs.tf
+++ b/examples/sandbox/outputs.tf
@@ -21,14 +21,15 @@ output "custom_topic" {
   }
 }
 
-output "customer_app" {
-  description = "Customer app details"
-  value = {
-    id     = prisma-airs_customer_app.main.customer_app_id
-    name   = prisma-airs_customer_app.main.app_name
-    status = prisma-airs_customer_app.main.status
-  }
-}
+# Customer app output — uncomment after importing an existing app:
+# output "customer_app" {
+#   description = "Customer app details"
+#   value = {
+#     id     = prisma-airs_customer_app.main.customer_app_id
+#     name   = prisma-airs_customer_app.main.app_name
+#     status = prisma-airs_customer_app.main.status
+#   }
+# }
 
 output "dlp_profiles" {
   description = "Available DLP profiles"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cdot65/prisma-airs-provider
 go 1.25.6
 
 require (
-	github.com/cdot65/prisma-airs-go v0.3.0
+	github.com/cdot65/prisma-airs-go v0.3.1
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
-github.com/cdot65/prisma-airs-go v0.3.0 h1:uQo3ZWQ/5+BRjlu8K4DU6jJy/ldlIN6GxKqI9L0QBnU=
-github.com/cdot65/prisma-airs-go v0.3.0/go.mod h1:+bG+LuYsBiy/+60UY91/g6RZmsyl3GjknBhJg11tMEg=
+github.com/cdot65/prisma-airs-go v0.3.1 h1:5ncr4nkNiFHoDCU7l6EgPg9VlZhtMdt+PuUEegsf0dM=
+github.com/cdot65/prisma-airs-go v0.3.1/go.mod h1:+bG+LuYsBiy/+60UY91/g6RZmsyl3GjknBhJg11tMEg=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/internal/provider/resource_customer_app.go
+++ b/internal/provider/resource_customer_app.go
@@ -36,7 +36,9 @@ type CustomerAppResourceModel struct {
 	Status           types.String `tfsdk:"status"`
 	CreatedBy        types.String `tfsdk:"created_by"`
 	UpdatedBy        types.String `tfsdk:"updated_by"`
+	AgentApp         types.Bool   `tfsdk:"agent_app"`
 	AiAgentFramework types.String `tfsdk:"ai_agent_framework"`
+	AiSecProfileName types.String `tfsdk:"ai_sec_profile_name"`
 }
 
 func (r *customerAppResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -45,7 +47,7 @@ func (r *customerAppResource) Metadata(_ context.Context, req resource.MetadataR
 
 func (r *customerAppResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manages a customer application registration.",
+		Description: "Manages an existing customer application in Prisma AIRS. Customer apps are created externally (via the AIRS console or when apps register); use `terraform import` to bring them under management.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
@@ -66,22 +68,22 @@ func (r *customerAppResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Description: "Name of the customer application.",
 			},
 			"tsg_id": schema.StringAttribute{
-				Optional:    true,
+				Computed:    true,
 				Description: "Tenant service group ID.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"model_name": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Model name associated with the app.",
 			},
 			"cloud_provider": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Cloud provider for the app.",
 			},
 			"environment": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Deployment environment.",
 			},
 			"status": schema.StringAttribute{
@@ -96,9 +98,17 @@ func (r *customerAppResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Optional:    true,
 				Description: "Identity of the user updating the app.",
 			},
+			"agent_app": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether this is an agent application.",
+			},
 			"ai_agent_framework": schema.StringAttribute{
 				Computed:    true,
 				Description: "AI agent framework.",
+			},
+			"ai_sec_profile_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Associated AI security profile name.",
 			},
 		},
 	}
@@ -116,28 +126,11 @@ func (r *customerAppResource) Configure(_ context.Context, req resource.Configur
 	r.client = client
 }
 
-func (r *customerAppResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan CustomerAppResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	createReq := management.CreateAppRequest{
-		AppName:       plan.AppName.ValueString(),
-		TsgID:         plan.TsgID.ValueString(),
-		CloudProvider: plan.CloudProvider.ValueString(),
-		Environment:   plan.Environment.ValueString(),
-	}
-
-	app, err := r.client.CustomerApps.Create(ctx, createReq)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to create customer app", err.Error())
-		return
-	}
-
-	mapAppToState(app, &plan)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+func (r *customerAppResource) Create(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.AddError(
+		"Create not supported",
+		"Customer apps cannot be created via the API. Use `terraform import prisma-airs_customer_app.<name> <app_name>` to manage an existing app.",
+	)
 }
 
 func (r *customerAppResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -147,7 +140,6 @@ func (r *customerAppResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	// SDK Get uses app_name as the lookup parameter.
 	app, err := r.client.CustomerApps.Get(ctx, state.AppName.ValueString())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
@@ -158,7 +150,6 @@ func (r *customerAppResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	// Preserve write-only values from state.
 	updatedByVal := state.UpdatedBy
 	mapAppToState(app, &state)
 	state.UpdatedBy = updatedByVal
@@ -185,7 +176,6 @@ func (r *customerAppResource) Update(ctx context.Context, req resource.UpdateReq
 		Environment:   plan.Environment.ValueString(),
 	}
 
-	// SDK Update uses customer_app_id as the identifier.
 	app, err := r.client.CustomerApps.Update(ctx, state.CustomerAppID.ValueString(), updateReq)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update customer app", err.Error())
@@ -208,7 +198,6 @@ func (r *customerAppResource) Delete(ctx context.Context, req resource.DeleteReq
 		updatedBy = "terraform"
 	}
 
-	// SDK Delete uses app_name and updated_by.
 	_, err := r.client.CustomerApps.Delete(ctx, state.AppName.ValueString(), updatedBy)
 	if err != nil {
 		if strings.Contains(err.Error(), "failed to parse response JSON") {
@@ -220,7 +209,6 @@ func (r *customerAppResource) Delete(ctx context.Context, req resource.DeleteReq
 }
 
 func (r *customerAppResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Import by app_name since SDK Get uses app_name.
 	appName := req.ID
 
 	app, err := r.client.CustomerApps.Get(ctx, appName)
@@ -244,5 +232,7 @@ func mapAppToState(app *management.CustomerApp, state *CustomerAppResourceModel)
 	state.Environment = types.StringValue(app.Environment)
 	state.Status = types.StringValue(app.Status)
 	state.CreatedBy = types.StringValue(app.CreatedBy)
+	state.AgentApp = types.BoolValue(app.AgentApp)
 	state.AiAgentFramework = types.StringValue(app.AiAgentFramework)
+	state.AiSecProfileName = types.StringValue(app.AiSecProfileName)
 }

--- a/internal/provider/unit_test.go
+++ b/internal/provider/unit_test.go
@@ -70,14 +70,16 @@ func TestMapApiKeyToState_emptyApiKey(t *testing.T) {
 
 func TestMapAppToState_basic(t *testing.T) {
 	app := &management.CustomerApp{
-		CustomerAppID: "app-789",
-		AppName:       "test-app",
-		TsgID:         "tsg-001",
-		ModelName:     "gpt-4",
-		CloudProvider: "aws",
-		Environment:   "production",
-		Status:        "active",
-		CreatedBy:     "user@example.com",
+		CustomerAppID:    "app-789",
+		AppName:          "test-app",
+		TsgID:            "tsg-001",
+		ModelName:        "gpt-4",
+		CloudProvider:    "aws",
+		Environment:      "production",
+		Status:           "active",
+		CreatedBy:        "user@example.com",
+		AgentApp:         true,
+		AiSecProfileName: "my-profile",
 	}
 
 	var state CustomerAppResourceModel
@@ -92,6 +94,10 @@ func TestMapAppToState_basic(t *testing.T) {
 	assertStringValue(t, "Environment", state.Environment, "production")
 	assertStringValue(t, "Status", state.Status, "active")
 	assertStringValue(t, "CreatedBy", state.CreatedBy, "user@example.com")
+	assertStringValue(t, "AiSecProfileName", state.AiSecProfileName, "my-profile")
+	if !state.AgentApp.ValueBool() {
+		t.Errorf("AgentApp = false, want true")
+	}
 }
 
 func TestMapAppToState_emptyFields(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Breaking:** `prisma-airs_customer_app` no longer supports create — API has no POST endpoint. Use `terraform import` to manage existing apps.
- Upgrade `prisma-airs-go` SDK to v0.3.1 (removes `Create`, fixes List endpoint URL, adds new fields)
- Add computed attributes: `agent_app`, `ai_sec_profile_name`
- `tsg_id` changed from Optional to Computed (set by API)
- Remove customer_app creation from sandbox examples, show import workflow
- Update docs and release notes

Closes #38