### PR TITLE
fix: replace invalid 'alert' action with 'block' in acceptance test

### DIFF
--- a/internal/provider/resource_security_profile_test.go
+++ b/internal/provider/resource_security_profile_test.go
@@ -23,7 +23,7 @@ func TestAccSecurityProfileResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("prisma-airs_security_profile.test", "profile_id"),
 					resource.TestCheckResourceAttr("prisma-airs_security_profile.test", "ai_security_profile.0.model_type", "default"),
 					resource.TestCheckResourceAttr("prisma-airs_security_profile.test", "ai_security_profile.0.model_protection.0.name", "prompt-injection"),
-					resource.TestCheckResourceAttr("prisma-airs_security_profile.test", "ai_security_profile.0.model_protection.0.action", "alert"),
+					resource.TestCheckResourceAttr("prisma-airs_security_profile.test", "ai_security_profile.0.model_protection.0.action", "block"),
 				),
 			},
 		},
@@ -40,7 +40,7 @@ resource "prisma-airs_security_profile" "test" {
 
     model_protection {
       name   = "prompt-injection"
-      action = "alert"
+      action = "block"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Acceptance test used `action = "alert"` for prompt-injection model protection — `"alert"` is not a valid API action value
- Profiles created with `"alert"` crash the AIRS tenant GUI when it tries to render them
- Changed to `action = "block"` (a valid value)

Closes #40

## Test plan

- [x] `make check` passes (fmt, vet, lint, tests)
- [x] No remaining `"alert"` action references in provider code
- [ ] CI passes