### PR TITLE
fix: preserve topic refs from plan before clearing state

### DIFF
--- a/internal/provider/resource_security_profile.go
+++ b/internal/provider/resource_security_profile.go
@@ -660,6 +660,7 @@ func mapProfileToState(ctx context.Context, profile *management.SecurityProfile,
 		return
 	}
 
+	priorAiProfiles := state.AiSecurityProfiles
 	state.AiSecurityProfiles = nil
 	for _, asp := range profile.Policy.AiSecurityProfiles {
 		model := AiSecurityProfileModel{
@@ -740,7 +741,7 @@ func mapProfileToState(ctx context.Context, profile *management.SecurityProfile,
 						}
 					} else {
 						// API may not return topics; preserve from prior state
-						tlModel.Topics = priorTopics(state, mpIdx, tlIdx)
+						tlModel.Topics = priorTopicsFromSlice(priorAiProfiles, mpIdx, tlIdx)
 					}
 					mpModel.TopicLists = append(mpModel.TopicLists, tlModel)
 				}
@@ -777,11 +778,11 @@ func mapProfileToState(ctx context.Context, profile *management.SecurityProfile,
 	}
 }
 
-func priorTopics(state *SecurityProfileResourceModel, mpIdx, tlIdx int) []TopicRefModel {
-	if len(state.AiSecurityProfiles) == 0 {
+func priorTopicsFromSlice(priorProfiles []AiSecurityProfileModel, mpIdx, tlIdx int) []TopicRefModel {
+	if len(priorProfiles) == 0 {
 		return nil
 	}
-	asp := state.AiSecurityProfiles[0]
+	asp := priorProfiles[0]
 	if mpIdx >= len(asp.ModelProtection) {
 		return nil
 	}


### PR DESCRIPTION
## Summary

- `mapProfileToState` set `state.AiSecurityProfiles = nil` before the mapping loop
- `priorTopics()` then read from `state` which was already nil — topics always lost
- Fix: save `priorAiProfiles` slice before clearing, pass it to the lookup function

This is the root cause of the remaining "block count changed from 1 to 0" errors on `topic_list[].topic` after v0.5.1.

## Test plan

- [x] `make check` passes
- [ ] CI passes
- [ ] `terraform apply` on security-profiles example succeeds cleanly