### PR TITLE
docs: update version refs (~> 0.4 → ~> 0.6, Go >= 1.25)

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.24 (for building from source)
+- [Go](https://golang.org/doc/install) >= 1.25 (for building from source)
 
 ## Terraform Registry
 
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.4"
+      version = "~> 0.6"
     }
   }
 }
@@ -45,7 +45,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.4"
+      version = "~> 0.6"
     }
   }
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     prisma-airs = {
       source  = "cdot65/prisma-airs"
-      version = "~> 0.4"
+      version = "~> 0.6"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update provider version constraint from `~> 0.4` to `~> 0.6` in installation and quick-start docs
- Update Go requirement from `>= 1.24` to `>= 1.25` (go.mod targets 1.25.6)

Closes #52

## Test plan
- [ ] mkdocs builds cleanly
- [ ] Version strings render correctly on all affected pages