### PR TITLE
docs: fix model security guide attribute (items → rules)

### DIFF
--- a/docs/guides/model-security-workflow.md
+++ b/docs/guides/model-security-workflow.md
@@ -18,6 +18,6 @@ resource "prisma-airs_model_security_group" "ml_models" {
 data "prisma-airs_model_security_rules" "all" {}
 
 output "available_rules" {
-  value = data.prisma-airs_model_security_rules.all.items[*].name
+  value = data.prisma-airs_model_security_rules.all.rules[*].name
 }
 ```


### PR DESCRIPTION
## Summary
- Fix incorrect attribute reference in model-security-workflow.md
- The `prisma-airs_model_security_rules` data source returns `rules`, not `items`

Closes #54

## Test plan
- [ ] mkdocs builds cleanly
- [ ] Example code references correct attribute