### PR TITLE
docs: update topic examples to show auto-resolve

### DIFF
--- a/docs/guides/managing-security-profiles.md
+++ b/docs/guides/managing-security-profiles.md
@@ -80,14 +80,15 @@ resource "prisma-airs_security_profile" "with_topics" {
 
         topic {
           topic_name = prisma-airs_custom_topic.financial.topic_name
-          topic_id   = prisma-airs_custom_topic.financial.topic_id
-          revision   = 1
         }
       }
     }
   }
 }
 ```
+
+!!! tip "Auto-Resolution"
+    The provider automatically resolves `topic_name` to `topic_id` and `revision` — no need to specify them manually.
 
 ## Managing API Keys
 

--- a/docs/resources/security-profile.md
+++ b/docs/resources/security-profile.md
@@ -139,8 +139,6 @@ resource "prisma-airs_security_profile" "topics" {
 
         topic {
           topic_name = "Recipe Generation"
-          topic_id   = prisma-airs_custom_topic.recipes.topic_id
-          revision   = 1
         }
       }
 
@@ -149,14 +147,15 @@ resource "prisma-airs_security_profile" "topics" {
 
         topic {
           topic_name = "Restricted Content"
-          topic_id   = prisma-airs_custom_topic.restricted.topic_id
-          revision   = 1
         }
       }
     }
   }
 }
 ```
+
+!!! tip "Auto-Resolution"
+    Since v0.6.2, the provider automatically resolves `topic_name` to `topic_id` and `revision` via the Topics API. You no longer need to specify these manually.
 
 ## Argument Reference
 


### PR DESCRIPTION
## Summary
- Update security-profile.md topic example to use only `topic_name` (auto-resolved since v0.6.2)
- Update managing-security-profiles.md topic example similarly
- Add admonition notes about auto-resolution behavior

Closes #53

## Test plan
- [ ] mkdocs builds cleanly
- [ ] Topic examples render correctly
- [ ] Admonition notes display properly